### PR TITLE
docs: ルート README を v1.0.0 の現状に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 A thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1.
 
-> **Phase 1 (MVP) — experimental.** Currently requires `zod@^3.23.0` (Zod 4 support is deferred to Phase 2; v4 reorders the `ZodType` generics and breaks Nanoka's field type inference). Expect breaking changes until v1.0.
+**Stable (1.0.0).** Supports Zod 3 and Zod 4.
 
 ## What is this
 
 Nanoka solves the repetitive wiring of Hono routing, Drizzle ORM, and Zod validation in Cloudflare Workers projects. Define a model once, and nanoka derives the DB schema, TypeScript types, and request validators from it. The remaining 20% — what your API exposes versus what the DB stores — stays explicit in each route handler.
 
-The design thesis is **"80% automatic, 20% explicit"**: automated derivation handles the common case, while intentional escape hatches keep the framework thin and auditable. `passwordHash` in the DB, for example, is excluded from responses by a deliberate `omit` in the validator call, not by hidden framework magic.
+The design thesis is **"80% automatic, 20% explicit"**: automated derivation handles the common case, while intentional escape hatches keep the framework thin and auditable. Field policies (`.serverOnly()`, `.writeOnly()`, `.readOnly()`) encode DB/API boundary intent directly on the field; `inputSchema('create' | 'update')` and `outputSchema()` apply those policies automatically. `passwordHash` in the DB, for example, can be marked `.serverOnly()` so it is excluded from both input and output schemas without a manual `omit` on every route.
 
 Nanoka targets Cloudflare Workers + D1 (SQLite) as first-class. It wraps Hono, so any Hono middleware and idiom works directly. Raw Drizzle is always accessible via `app.db` when the typed API is not enough.
 
@@ -30,8 +30,10 @@ docs/                     # Design documents and implementation plan
 - [Library README](packages/nanoka/README.md) — install, quickstart, full API reference
 - [Contributing](CONTRIBUTING.md) — development workflow and manual release process
 - [Design document](docs/nanoka.md) — architecture decisions and design rationale
-- [Backlog](docs/backlog.md) — current follow-ups, accepted risks, and Phase 2 candidates
-- [Phase 1 plan](docs/phase1-plan.md) — Phase 1 completion history (M0–M8, all done)
+- [Backlog](docs/backlog.md) — accepted risks, follow-ups, and Phase 3 candidates
+- [Phase 1 plan](docs/phase1-plan.md) — Phase 1 completion history (M0–M8, done)
+- [Phase 1.5 plan](docs/phase1.5-plan.md) — Phase 1.5 completion history (M1–M5, done)
+- [Phase 2 plan](docs/phase2-plan.md) — Phase 2 completion history (M1–M4, done)
 - [Example app](examples/basic/README.md) — complete CRUD example with deployment steps
 
 ## Development


### PR DESCRIPTION
- 「Phase 1 (MVP) — experimental」警告を削除。v1.0.0 安定版・Zod 3/4 両対応を明記
- "What is this" にフィールドポリシー（serverOnly / writeOnly / readOnly）と
  inputSchema / outputSchema を追記（Phase 2 で実装済みの安定 API）
- Documentation セクションのバックログ説明を「Phase 3 candidates」に更新
- Phase 1.5 / Phase 2 の完了履歴リンクを追加

https://claude.ai/code/session_01RM1yRiN5oR3whNoCjLhgN7