### PR TITLE
feat: Phase 2後半 M3 — create-nanoka-app CLI スキャフォールダ

### DIFF
--- a/.github/workflows/onboarding.yml
+++ b/.github/workflows/onboarding.yml
@@ -42,3 +42,18 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run onboarding zod@^4 regression E2E (expects typecheck failure)
         run: bash e2e/onboarding/scripts/run-onboarding-zod4.sh
+
+  onboarding-scaffold:
+    name: Onboarding (scaffold)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v4.4.0 / v5.0.0 (same commit)
+        with:
+          version: 9.15.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: bash e2e/onboarding/scripts/run-onboarding-scaffold.sh

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -24,3 +24,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm -C packages/nanoka publish --dry-run --no-git-checks
+
+      - name: Build create-nanoka-app
+        run: pnpm -C packages/create-nanoka-app build
+
+      - name: Publish create-nanoka-app (dry run)
+        working-directory: packages/create-nanoka-app
+        run: pnpm publish --dry-run --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,25 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Verify create-nanoka-app version matches nanoka
+        shell: bash
+        run: |
+          NANOKA_VERSION=$(node -p "require('./packages/nanoka/package.json').version")
+          CLI_VERSION=$(node -p "require('./packages/create-nanoka-app/package.json').version")
+          if [ "$NANOKA_VERSION" != "$CLI_VERSION" ]; then
+            echo "::error::create-nanoka-app version ($CLI_VERSION) must equal @nanokajs/core version ($NANOKA_VERSION)."
+            exit 1
+          fi
+
+      - name: Build create-nanoka-app
+        run: pnpm -C packages/create-nanoka-app build
+
+      - name: Typecheck create-nanoka-app
+        run: pnpm -C packages/create-nanoka-app typecheck
+
+      - name: Test create-nanoka-app
+        run: pnpm -C packages/create-nanoka-app test
+
       - run: pnpm -C packages/nanoka build
 
       - run: pnpm -C packages/nanoka test
@@ -65,4 +84,12 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/nanoka
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
+
+      - name: Publish create-nanoka-app to npm
+        working-directory: packages/create-nanoka-app
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance

--- a/docs/phase2後半-plan.md
+++ b/docs/phase2後半-plan.md
@@ -68,21 +68,21 @@ Phase 2C（M3）で確立したモデル単位の component 生成を、route-le
 
 `docs/nanoka.md` Phase 3 "`npx create-nanoka-app`" 由来。`docs/backlog.md §4.7` で整備した onboarding parity CI と連携させることで、scaffold 産出物の parity を自動保証する。
 
-- [ ] **3.1** `packages/create-nanoka-app` の新規パッケージ追加
+- [x] **3.1** `packages/create-nanoka-app` の新規パッケージ追加
   - `pnpm-workspace.yaml` に `packages/create-nanoka-app` を追加
   - `package.json` に `bin: { "create-nanoka-app": "dist/index.js" }` を設定
   - `tsup` でビルド、`pnpm -C packages/create-nanoka-app build` が通ること
-- [ ] **3.2** scaffold テンプレート実装
+- [x] **3.2** scaffold テンプレート実装
   - Hono + D1 + Nanoka の最小構成（`src/index.ts` / `drizzle.config.ts` / `wrangler.toml` / `tsconfig.json`）を `templates/default/` に用意
   - README の Quickstart と完全に一致する構成にする
   - `@nanokajs/core` のバージョン指定は `package.json` から動的に取得
-- [ ] **3.3** CLI 実装（対話 or 非対話）
+- [x] **3.3** CLI 実装（対話 or 非対話）
   - `pnpm create nanoka-app <dir>` / `npx create-nanoka-app <dir>` でプロジェクト生成
   - 最小オプション: `--template default`（現時点は default のみ）
-- [ ] **3.4** onboarding parity CI との連携
+- [x] **3.4** onboarding parity CI との連携
   - `e2e/onboarding/` の既存スクリプトを `create-nanoka-app` 産出物に対して回すよう拡張
   - scaffold 産出物で `tsc --noEmit` / `drizzle-kit generate` が成功することを assert
-- [ ] **3.5** `create-nanoka-app` を npm registry に publish
+- [x] **3.5** `create-nanoka-app` を npm registry に publish
   - `packages/create-nanoka-app/package.json` に publish 設定
   - `publish.yml` / `publish-dry-run.yml` に `create-nanoka-app` を追加
 

--- a/e2e/onboarding/scripts/run-onboarding-scaffold.sh
+++ b/e2e/onboarding/scripts/run-onboarding-scaffold.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORK_DIR="$(mktemp -d)"
+PACK_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$WORK_DIR" "$PACK_DIR"' EXIT
+
+echo "=== Building packages ==="
+pnpm -C "$REPO_ROOT/packages/nanoka" build
+pnpm -C "$REPO_ROOT/packages/nanoka" pack --pack-destination "$PACK_DIR"
+TARBALL="$(ls "$PACK_DIR"/*.tgz | head -n1)"
+echo "tarball=$TARBALL"
+
+pnpm -C "$REPO_ROOT/packages/create-nanoka-app" build
+
+echo "=== Scaffolding project ==="
+node "$REPO_ROOT/packages/create-nanoka-app/dist/index.js" "$WORK_DIR/scaffold-test" --force
+
+echo "=== Injecting local nanoka tarball ==="
+cd "$WORK_DIR/scaffold-test"
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+pkg.dependencies['@nanokajs/core'] = 'file:$TARBALL';
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+"
+pnpm install --no-frozen-lockfile
+
+echo "=== Running checks ==="
+# nanoka generate: may fail if @nanokajs/core version doesn't have CLI yet; drizzle-kit generate is the hard check
+pnpm exec nanoka generate || true
+pnpm exec drizzle-kit generate
+pnpm exec tsc --noEmit
+
+echo "=== Asserting migration files ==="
+ls drizzle/migrations/*.sql || { echo "ERROR: No migration files generated"; exit 1; }
+
+echo "=== Scaffold onboarding passed ==="

--- a/packages/create-nanoka-app/README.md
+++ b/packages/create-nanoka-app/README.md
@@ -1,0 +1,23 @@
+# create-nanoka-app
+
+Create a new Nanoka (Hono + Drizzle + D1) project in seconds.
+
+## Usage
+
+```bash
+pnpm create nanoka-app my-app
+# or
+npx create-nanoka-app my-app
+```
+
+## Getting started
+
+After scaffolding:
+
+```bash
+cd my-app
+pnpm install
+pnpm exec nanoka generate
+pnpm exec drizzle-kit generate
+pnpm dev
+```

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "create-nanoka-app",
+  "version": "1.0.0",
+  "description": "Create a new Nanoka (Hono + D1) project",
+  "type": "module",
+  "bin": {
+    "create-nanoka-app": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "templates",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && node ./scripts/prepend-shebang.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "prepublishOnly": "pnpm build && pnpm typecheck && pnpm test"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nanokajs/nanoka.git"
+  },
+  "license": "MIT"
+}

--- a/packages/create-nanoka-app/scripts/prepend-shebang.mjs
+++ b/packages/create-nanoka-app/scripts/prepend-shebang.mjs
@@ -1,0 +1,19 @@
+import { chmodSync, promises as fs } from 'node:fs'
+import { join } from 'node:path'
+
+async function prependShebang() {
+  const cliPath = join(process.cwd(), 'dist/index.js')
+
+  try {
+    const content = await fs.readFile(cliPath, 'utf-8')
+    const withShebang = content.startsWith('#!/') ? content : `#!/usr/bin/env node\n${content}`
+    await fs.writeFile(cliPath, withShebang, 'utf-8')
+    chmodSync(cliPath, 0o755)
+    console.log(`✓ Added shebang to ${cliPath}`)
+  } catch (error) {
+    console.error('Error prepending shebang:', error)
+    process.exit(1)
+  }
+}
+
+prependShebang()

--- a/packages/create-nanoka-app/src/index.ts
+++ b/packages/create-nanoka-app/src/index.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+import { cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { basename, dirname, extname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export type Options = { targetDir: string; template: 'default'; force: boolean }
+export type ParseResult = Options | { kind: 'help' } | { kind: 'version' }
+
+export function parseArgs(argv: string[]): ParseResult {
+  const args = argv.slice(2)
+
+  if (args.includes('--help') || args.includes('-h')) {
+    return { kind: 'help' }
+  }
+  if (args.includes('--version') || args.includes('-v')) {
+    return { kind: 'version' }
+  }
+
+  let targetDir = ''
+  let template: 'default' = 'default'
+  let force = false
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg === '--template') {
+      const next = args[i + 1]
+      if (next !== 'default') {
+        throw new Error(`Unknown template: "${next ?? ''}". Available templates: default`)
+      }
+      template = next
+      i++
+    } else if (arg === '--force') {
+      force = true
+    } else if (!arg.startsWith('-')) {
+      targetDir = arg
+    }
+  }
+
+  if (!targetDir) {
+    throw new Error('Please specify a project directory: create-nanoka-app <dir>')
+  }
+
+  return { targetDir, template, force }
+}
+
+export async function copyTemplate(
+  srcDir: string,
+  destDir: string,
+  vars: Record<string, string>,
+): Promise<void> {
+  await mkdir(destDir, { recursive: true })
+
+  const entries = await readdir(srcDir, { withFileTypes: true })
+  for (const entry of entries) {
+    const srcPath = join(srcDir, entry.name)
+    const isTmpl = extname(entry.name) === '.tmpl'
+    const destName = isTmpl ? basename(entry.name, '.tmpl') : entry.name
+    const destPath = join(destDir, destName)
+
+    if (entry.isDirectory()) {
+      await copyTemplate(srcPath, destPath, vars)
+    } else if (isTmpl) {
+      let content = await readFile(srcPath, 'utf-8')
+      for (const [key, value] of Object.entries(vars)) {
+        content = content.replaceAll(`{{${key}}}`, value)
+      }
+      await writeFile(destPath, content, 'utf-8')
+    } else {
+      await cp(srcPath, destPath)
+    }
+  }
+}
+
+export async function scaffold(opts: Options): Promise<void> {
+  const targetDir = resolve(process.cwd(), opts.targetDir)
+
+  const packageName = basename(targetDir)
+
+  // Validate packageName against npm naming rules
+  const packageNameRegex = /^[a-z0-9][a-z0-9\-_.]*$/
+  if (!packageNameRegex.test(packageName)) {
+    throw new Error(
+      `Invalid package name: '${packageName}'. Must match /^[a-z0-9][a-z0-9-_.]*$/ (lowercase letters, digits, hyphens, dots, underscores).`,
+    )
+  }
+
+  try {
+    const entries = await readdir(targetDir)
+    if (entries.length > 0 && !opts.force) {
+      throw new Error(
+        `Directory "${opts.targetDir}" already exists and is not empty. Use --force to overwrite.`,
+      )
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err
+    }
+  }
+
+  const selfDir = dirname(fileURLToPath(import.meta.url))
+  const templateDir = join(selfDir, '../templates', opts.template)
+
+  const require = createRequire(import.meta.url)
+  const { version } = require('../package.json') as { version: string }
+  const vars: Record<string, string> = {
+    packageName,
+    nanokaVersion: version,
+  }
+
+  await copyTemplate(templateDir, targetDir, vars)
+
+  console.log(`\nCreated "${packageName}" at ${targetDir}`)
+  console.log('\nNext steps:')
+  console.log(`  cd ${opts.targetDir}`)
+  console.log('  pnpm install')
+  console.log('  pnpm exec nanoka generate')
+  console.log('  pnpm exec drizzle-kit generate')
+  console.log('  pnpm dev')
+}
+
+async function main(): Promise<void> {
+  const result = parseArgs(process.argv)
+
+  if ('kind' in result) {
+    if (result.kind === 'help') {
+      console.log('Usage: create-nanoka-app <dir> [--template default] [--force]')
+      console.log('\nOptions:')
+      console.log('  --template <name>  Template to use (default: default)')
+      console.log('  --force            Overwrite existing directory')
+      console.log('  --help, -h         Show this help message')
+      console.log('  --version, -v      Show version number')
+      return
+    }
+    if (result.kind === 'version') {
+      const require = createRequire(import.meta.url)
+      const { version } = require('../package.json') as { version: string }
+      console.log(version)
+      return
+    }
+  }
+
+  await scaffold(result as Options)
+}
+
+if (process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((err: unknown) => {
+    console.error((err as Error).message ?? err)
+    process.exit(1)
+  })
+}

--- a/packages/create-nanoka-app/templates/default/.gitignore
+++ b/packages/create-nanoka-app/templates/default/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.wrangler
+.dev.vars

--- a/packages/create-nanoka-app/templates/default/README.md
+++ b/packages/create-nanoka-app/templates/default/README.md
@@ -1,0 +1,12 @@
+# My Nanoka App
+
+A Hono + Drizzle + D1 project scaffolded with `create-nanoka-app`.
+
+## Quickstart
+
+```bash
+pnpm install
+pnpm exec nanoka generate
+pnpm exec drizzle-kit generate
+pnpm dev
+```

--- a/packages/create-nanoka-app/templates/default/drizzle.config.ts
+++ b/packages/create-nanoka-app/templates/default/drizzle.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: './drizzle/schema.ts',
+  out: './drizzle/migrations',
+  dialect: 'sqlite',
+  driver: 'd1-http',
+})

--- a/packages/create-nanoka-app/templates/default/nanoka.config.ts
+++ b/packages/create-nanoka-app/templates/default/nanoka.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@nanokajs/core/config'
+import { userFields, userTableName } from './src/models/user'
+
+export default defineConfig({
+  models: [
+    {
+      name: userTableName,
+      fields: userFields,
+    },
+  ],
+  output: './drizzle/schema.ts',
+})

--- a/packages/create-nanoka-app/templates/default/package.json.tmpl
+++ b/packages/create-nanoka-app/templates/default/package.json.tmpl
@@ -1,0 +1,22 @@
+{
+  "name": "{{packageName}}",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "db:generate": "drizzle-kit generate",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nanokajs/core": "{{nanokaVersion}}",
+    "hono": "^4.0.0",
+    "drizzle-orm": "^0.45.2",
+    "zod": "^3.23.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240925.0",
+    "drizzle-kit": "^0.28.0",
+    "typescript": "^5.6.0",
+    "wrangler": "^3.80.0"
+  }
+}

--- a/packages/create-nanoka-app/templates/default/src/index.ts
+++ b/packages/create-nanoka-app/templates/default/src/index.ts
@@ -1,0 +1,38 @@
+import { d1Adapter, nanoka } from '@nanokajs/core'
+import { z } from 'zod'
+import { userFields, userTableName } from './models/user'
+
+export interface Env {
+  DB: D1Database
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const app = nanoka<{ Bindings: Env }>(d1Adapter(env.DB))
+    const User = app.model(userTableName, userFields)
+
+    app.post(
+      '/users',
+      User.validator('json', { omit: ['id', 'passwordHash', 'createdAt'] }),
+      async (c) => {
+        const body = c.req.valid('json')
+        const created = await User.create({
+          ...body,
+          id: crypto.randomUUID(),
+          passwordHash: 'hashed_value_here',
+          createdAt: new Date(),
+        })
+        const user = User.schema({ omit: ['passwordHash'] }).parse(created)
+        return c.json(user, 201)
+      },
+    )
+
+    app.get('/users', async (c) => {
+      const users = await User.findMany({ limit: 20 })
+      const result = z.array(User.schema({ omit: ['passwordHash'] })).parse(users)
+      return c.json(result)
+    })
+
+    return app.fetch(req, env, ctx)
+  },
+}

--- a/packages/create-nanoka-app/templates/default/src/models/user.ts
+++ b/packages/create-nanoka-app/templates/default/src/models/user.ts
@@ -1,0 +1,12 @@
+import { t } from '@nanokajs/core'
+
+export const userTableName = 'users'
+
+export const userFields = {
+  id: t.uuid().primary(),
+  name: t.string().min(1).max(100),
+  email: t.string().email().unique(),
+  passwordHash: t.string().writeOnly(),
+  serverToken: t.string().serverOnly().optional(),
+  createdAt: t.timestamp().default(() => new Date()),
+}

--- a/packages/create-nanoka-app/templates/default/tsconfig.json
+++ b/packages/create-nanoka-app/templates/default/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*", "*.config.ts", "nanoka.config.ts"]
+}

--- a/packages/create-nanoka-app/templates/default/wrangler.toml.tmpl
+++ b/packages/create-nanoka-app/templates/default/wrangler.toml.tmpl
@@ -1,0 +1,13 @@
+name = "{{packageName}}"
+main = "src/index.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "{{packageName}}"
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "drizzle/migrations"
+
+[vars]
+ENVIRONMENT = "development"

--- a/packages/create-nanoka-app/test/scaffold.test.ts
+++ b/packages/create-nanoka-app/test/scaffold.test.ts
@@ -1,0 +1,144 @@
+import { access, mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from 'vitest'
+import { copyTemplate, parseArgs, scaffold } from '../src/index'
+
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'create-nanoka-app-test-'))
+}
+
+test('scaffold creates package.json with correct name', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'my-project')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+
+  const content = await readFile(join(targetDir, 'package.json'), 'utf-8')
+  const pkg = JSON.parse(content) as { name: string; dependencies: Record<string, string> }
+
+  expect(pkg.name).toBe('my-project')
+  expect(pkg.dependencies['@nanokajs/core']).toBeDefined()
+  expect(pkg.dependencies['@nanokajs/core']).not.toContain('{{')
+})
+
+test('scaffold creates wrangler.toml with packageName substituted', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'my-app')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+
+  const content = await readFile(join(targetDir, 'wrangler.toml'), 'utf-8')
+  expect(content).toContain('name = "my-app"')
+  expect(content).toContain('database_name = "my-app"')
+  expect(content).not.toContain('{{packageName}}')
+})
+
+test('scaffold creates src/index.ts', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'my-worker')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+
+  await expect(access(join(targetDir, 'src', 'index.ts'))).resolves.toBeUndefined()
+})
+
+test('scaffold src/index.ts contains User.findMany and User.validator', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'my-worker')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+
+  const content = await readFile(join(targetDir, 'src', 'index.ts'), 'utf-8')
+  expect(content).toContain('User.findMany')
+  expect(content).toContain('User.validator')
+})
+
+test('scaffold fails without --force on non-empty directory', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'existing')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+
+  await expect(scaffold({ targetDir, template: 'default', force: false })).rejects.toThrow(
+    'already exists and is not empty',
+  )
+})
+
+test('scaffold succeeds with --force on non-empty directory', async () => {
+  const tmp = await makeTmpDir()
+  const targetDir = join(tmp, 'existing2')
+
+  await scaffold({ targetDir, template: 'default', force: false })
+  await expect(scaffold({ targetDir, template: 'default', force: true })).resolves.toBeUndefined()
+})
+
+test('parseArgs: --help returns kind:help', () => {
+  expect(parseArgs(['node', 'create-nanoka-app', '--help'])).toEqual({ kind: 'help' })
+  expect(parseArgs(['node', 'create-nanoka-app', '-h'])).toEqual({ kind: 'help' })
+})
+
+test('parseArgs: --version returns kind:version', () => {
+  expect(parseArgs(['node', 'create-nanoka-app', '--version'])).toEqual({ kind: 'version' })
+  expect(parseArgs(['node', 'create-nanoka-app', '-v'])).toEqual({ kind: 'version' })
+})
+
+test('parseArgs: invalid template throws', () => {
+  expect(() => parseArgs(['node', 'create-nanoka-app', 'my-app', '--template', 'unknown'])).toThrow(
+    'Unknown template',
+  )
+})
+
+test('parseArgs: no dir throws', () => {
+  expect(() => parseArgs(['node', 'create-nanoka-app'])).toThrow('Please specify')
+})
+
+test('parseArgs: basic args', () => {
+  const result = parseArgs(['node', 'create-nanoka-app', 'my-app'])
+  expect(result).toEqual({ targetDir: 'my-app', template: 'default', force: false })
+})
+
+test('parseArgs: --force flag', () => {
+  const result = parseArgs(['node', 'create-nanoka-app', 'my-app', '--force'])
+  expect(result).toEqual({ targetDir: 'my-app', template: 'default', force: true })
+})
+
+test('scaffold rejects invalid package names', async () => {
+  const tmp = await makeTmpDir()
+
+  // Test invalid package names
+  const invalidNames = ['My-App', '@invalid', 'app!', '-start-with-dash', 'app@', 'app#']
+  for (const invalidName of invalidNames) {
+    await expect(
+      scaffold({ targetDir: join(tmp, invalidName), template: 'default', force: false }),
+    ).rejects.toThrow('Invalid package name')
+  }
+})
+
+test('scaffold accepts valid package names', async () => {
+  const tmp = await makeTmpDir()
+
+  // Test valid package names
+  const validNames = ['my-app', 'my_app', 'my.app', 'myapp', 'app123', 'a']
+  for (const validName of validNames) {
+    const targetDir = join(tmp, validName)
+    await expect(
+      scaffold({ targetDir, template: 'default', force: false }),
+    ).resolves.toBeUndefined()
+  }
+})
+
+test('copyTemplate substitutes all placeholders', async () => {
+  const tmp = await makeTmpDir()
+  const srcDir = join(tmp, 'src')
+  const destDir = join(tmp, 'dest')
+
+  const { mkdir, writeFile } = await import('node:fs/promises')
+  await mkdir(srcDir, { recursive: true })
+  await writeFile(join(srcDir, 'hello.txt.tmpl'), 'Hello {{name}}, version {{version}}!')
+
+  await copyTemplate(srcDir, destDir, { name: 'world', version: '1.0.0' })
+
+  const content = await readFile(join(destDir, 'hello.txt'), 'utf-8')
+  expect(content).toBe('Hello world, version 1.0.0!')
+})

--- a/packages/create-nanoka-app/tsconfig.json
+++ b/packages/create-nanoka-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*", "scripts/**/*"]
+}

--- a/packages/create-nanoka-app/tsup.config.ts
+++ b/packages/create-nanoka-app/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  clean: true,
+  dts: false,
+})

--- a/packages/create-nanoka-app/vitest.config.ts
+++ b/packages/create-nanoka-app/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,21 @@ importers:
         specifier: '>=3.114.17 <4.0.0'
         version: 3.114.17(@cloudflare/workers-types@4.20260501.1)
 
+  packages/create-nanoka-app:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@25.6.0)
+
   packages/nanoka:
     dependencies:
       '@hono/zod-validator':
@@ -1639,7 +1654,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:


### PR DESCRIPTION
## Summary

- `npx create-nanoka-app <dir>` / `pnpm create nanoka-app <dir>` で Hono + D1 + Nanoka の最小プロジェクトを生成する `packages/create-nanoka-app` を新規追加
- onboarding parity CI で scaffold 産出物の整合性（`tsc --noEmit` / `drizzle-kit generate`）を常時保証
- npm publish フローに `create-nanoka-app` を組み込み（version 整合チェック付き）

## Changes

### New package: `packages/create-nanoka-app`
- **CLI 実装** (`src/index.ts`): 依存ゼロ（Node 標準 API のみ）
  - `--template default` / `--force` / `--help` / `--version` オプション
  - `packageName` の npm 規則バリデーション（`/^[a-z0-9][a-z0-9-_.]*$/`）
  - `.tmpl` ファイルの `{{packageName}}` / `{{nanokaVersion}}` プレースホルダ置換
- **テンプレート** (`templates/default/`): `e2e/onboarding/fixture` と整合した最小構成
  - `src/index.ts`, `src/models/user.ts`, `drizzle.config.ts`, `wrangler.toml.tmpl`, `tsconfig.json`, `nanoka.config.ts`, `.gitignore`, `README.md`
- **テスト** (`test/scaffold.test.ts`): 15 件（プレースホルダ置換・バリデーション・内容確認等）

### CI
- `e2e/onboarding/scripts/run-onboarding-scaffold.sh`: tarball inject → scaffold → `drizzle-kit generate` / `tsc --noEmit` をアサート
- `.github/workflows/onboarding.yml`: `onboarding-scaffold` job 追加
- `.github/workflows/publish.yml`: version 整合チェックを publish より前に移動 + create-nanoka-app の build / test / publish ステップ追加（`NODE_AUTH_TOKEN` 明示）
- `.github/workflows/publish-dry-run.yml`: create-nanoka-app dry-run ステップ追加

## Security

- `packageName` のインジェクション対策としてバリデーション追加
- `publish.yml` の検証順序を修正（core publish 前に CLI の整合チェック・ビルド・テストを実施）
- publish ステップの `NODE_AUTH_TOKEN` env を明示

## Test plan

- [x] `pnpm -C packages/create-nanoka-app build` — green
- [x] `pnpm -C packages/create-nanoka-app test` — 15 tests passed
- [x] `pnpm -C packages/create-nanoka-app typecheck` — no errors
- [x] `pnpm lint` — no new errors
- [ ] `bash e2e/onboarding/scripts/run-onboarding-scaffold.sh` — CI で確認予定
- [ ] `pnpm create nanoka-app my-app` → `tsc --noEmit` / `drizzle-kit generate` — CI で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)