### PR TITLE
fix: publish.yml から NODE_AUTH_TOKEN を削除（trusted publishing 使用）

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,12 +84,8 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/nanoka
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance
 
       - name: Publish create-nanoka-app to npm
         working-directory: packages/create-nanoka-app
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance


### PR DESCRIPTION
## Summary

PR #9 マージ後に fix コミットをプッシュしたため main に反映されていなかった修正を再適用。

## Changes

- `.github/workflows/publish.yml`: `packages/nanoka` と `packages/create-nanoka-app` 両方の `npm publish` ステップから `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env を削除

## Why

このプロジェクトは npm の **trusted publishing**（GitHub Actions OIDC）を使っているため、npm token を GitHub Secrets に持たせる必要がなく、かつ持たせない方針（GitHubへのシークレット漏洩リスク対策）。
セキュリティレビューの指摘を誤適用して追加していたが、trusted publishing では不要なため元に戻す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)