### PR TITLE
fix: npx / pnpm create 経由で main() が呼ばれないバグを修正 (v1.0.1)

### DIFF
--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/create-nanoka-app/src/index.ts
+++ b/packages/create-nanoka-app/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs'
 import { cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { basename, dirname, extname, join, resolve } from 'node:path'
@@ -143,7 +144,7 @@ async function main(): Promise<void> {
   await scaffold(result as Options)
 }
 
-if (process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (process.argv[1] != null && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main().catch((err: unknown) => {
     console.error((err as Error).message ?? err)
     process.exit(1)

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",


### PR DESCRIPTION
## Summary

- `npx create-nanoka-app <dir>` および `pnpm create nanoka-app <dir>` を実行してもアプリが作成されない問題を修正
- 原因: `resolve(process.argv[1])` はシンボリックリンクを解決しないため、npx/pnpm が生成するシンボリックリンク経由で実行すると `fileURLToPath(import.meta.url)` と一致せず `main()` が呼ばれなかった
- 修正: `realpathSync(process.argv[1])` に変更してシンボリックリンクを解決
- バージョンを 1.0.0 → 1.0.1 に上げて再 publish 対象とする

## Test plan

- [x] `pnpm test` (15 tests passed)
- [x] シンボリックリンク経由での手動動作確認済み (`ln -sf dist/index.js /tmp/sym && node /tmp/sym <dir>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)