### PR TITLE
fix: optional フィールドが D1 の null を拒否して 500 エラーになる問題を修正

### DIFF
--- a/e2e/onboarding/fixture/src/index.ts
+++ b/e2e/onboarding/fixture/src/index.ts
@@ -22,7 +22,7 @@ export default {
           passwordHash: 'hashed_value_here',
           createdAt: new Date(),
         })
-        const user = User.schema({ omit: ['passwordHash'] }).parse(created)
+        const user = User.outputSchema({ omit: ['passwordHash'] }).parse(created)
         return c.json(user, 201)
       },
     )
@@ -42,7 +42,7 @@ export default {
 
     app.get('/users', async (c) => {
       const users = await User.findMany({ limit: 20 })
-      const result = z.array(User.schema({ omit: ['passwordHash'] })).parse(users)
+      const result = z.array(User.outputSchema({ omit: ['passwordHash'] })).parse(users)
       return c.json(result)
     })
 

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/create-nanoka-app/templates/default/src/index.ts
+++ b/packages/create-nanoka-app/templates/default/src/index.ts
@@ -22,14 +22,14 @@ export default {
           passwordHash: 'hashed_value_here',
           createdAt: new Date(),
         })
-        const user = User.schema({ omit: ['passwordHash'] }).parse(created)
+        const user = User.outputSchema({ omit: ['passwordHash'] }).parse(created)
         return c.json(user, 201)
       },
     )
 
     app.get('/users', async (c) => {
       const users = await User.findMany({ limit: 20 })
-      const result = z.array(User.schema({ omit: ['passwordHash'] })).parse(users)
+      const result = z.array(User.outputSchema({ omit: ['passwordHash'] })).parse(users)
       return c.json(result)
     })
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/field/builder.ts
+++ b/packages/nanoka/src/field/builder.ts
@@ -47,9 +47,9 @@ export abstract class BaseFieldBuilder<
   protected applyModifiersToZod(baseSchema: z.ZodTypeAny): z.ZodTypeAny {
     let schema = baseSchema
 
-    // Apply optional
+    // Apply optional — use nullable() first so D1/SQLite null values are accepted
     if (this.modifiers.optional) {
-      schema = schema.optional()
+      schema = schema.nullable().optional()
     }
 
     // Apply default

--- a/packages/nanoka/src/openapi/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/packages/nanoka/src/openapi/__tests__/__snapshots__/openapi.test.ts.snap
@@ -16,7 +16,9 @@ exports[`OpenAPI component generation > matches snapshot 1`] = `
         "format": "email",
         "type": "string",
       },
-      "metadata": {},
+      "metadata": {
+        "nullable": true,
+      },
       "name": {
         "maxLength": 100,
         "minLength": 1,
@@ -28,6 +30,7 @@ exports[`OpenAPI component generation > matches snapshot 1`] = `
         "writeOnly": true,
       },
       "profile": {
+        "nullable": true,
         "properties": {
           "count": {
             "type": "integer",
@@ -95,13 +98,16 @@ exports[`OpenAPI component generation > matches snapshot 1`] = `
         "readOnly": true,
         "type": "string",
       },
-      "metadata": {},
+      "metadata": {
+        "nullable": true,
+      },
       "name": {
         "maxLength": 100,
         "minLength": 1,
         "type": "string",
       },
       "profile": {
+        "nullable": true,
         "properties": {
           "count": {
             "type": "integer",
@@ -159,7 +165,9 @@ exports[`OpenAPI component generation > matches snapshot 1`] = `
         "format": "email",
         "type": "string",
       },
-      "metadata": {},
+      "metadata": {
+        "nullable": true,
+      },
       "name": {
         "maxLength": 100,
         "minLength": 1,
@@ -171,6 +179,7 @@ exports[`OpenAPI component generation > matches snapshot 1`] = `
         "writeOnly": true,
       },
       "profile": {
+        "nullable": true,
         "properties": {
           "count": {
             "type": "integer",

--- a/packages/nanoka/src/openapi/__tests__/openapi.test.ts
+++ b/packages/nanoka/src/openapi/__tests__/openapi.test.ts
@@ -147,8 +147,9 @@ describe('OpenAPI component generation', () => {
     expect(properties.age).toEqual({ type: 'integer', minimum: 0, maximum: 150 })
     expect(properties.score).toEqual({ type: 'number', minimum: 0, maximum: 1 })
     expect(properties.active).toEqual({ type: 'boolean' })
-    expect(properties.metadata).toEqual({})
+    expect(properties.metadata).toEqual({ nullable: true })
     expect(properties.profile).toEqual({
+      nullable: true,
       type: 'object',
       properties: {
         foo: { type: 'string' },


### PR DESCRIPTION
## 問題

`npx create-nanoka-app` で生成したアプリで POST /users を実行すると 500 エラーが発生する。

```json
{
  "0": {
    "expected": "string",
    "code": "invalid_type",
    "path": ["serverToken"],
    "message": "Invalid input: expected string, received null"
  }
}
```

## 原因

2 つの問題が重なっていた。

### 1. `applyModifiersToZod` が D1 の null を拒否する

D1/SQLite は未設定の列に `undefined` ではなく `null` を返す。しかし `BaseFieldBuilder.applyModifiersToZod` は `schema.optional()` のみ適用していたため、生成された Zod スキーマ（`z.string().optional()`）が `null` を拒否していた。

ドキュメントコメントにも「allows undefined / null」と記載されていたが実装が追いついていなかった。

**修正:** `schema.optional()` → `schema.nullable().optional()`

### 2. テンプレートが `User.schema()` を使っていた

`User.schema()` は serverOnly などのポリシーを適用しないため、`serverToken`（`serverOnly`）がスキーマに残り、DB から返ってきた `serverToken: null` の検証が走っていた。

API レスポンスを生成する際は `User.outputSchema()` を使うのが正しい（serverOnly / writeOnly フィールドを自動除外）。

**修正:** `User.schema()` → `User.outputSchema()` をテンプレートと e2e fixture で適用

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `packages/nanoka/src/field/builder.ts` | `.nullable().optional()` に変更 |
| `packages/create-nanoka-app/templates/default/src/index.ts` | `outputSchema()` に変更 |
| `e2e/onboarding/fixture/src/index.ts` | `outputSchema()` に変更 |
| `packages/nanoka/src/openapi/__tests__/openapi.test.ts` | optional JSON フィールドが `nullable: true` を持つことを反映 |
| `packages/nanoka/src/openapi/__tests__/__snapshots__/openapi.test.ts.snap` | スナップショット更新 |

## 副作用

optional な JSON フィールドの OpenAPI スキーマに `nullable: true` が追加される。これは D1 の実際の動作と一致する正しい変更。