### PR TITLE
docs: Relations API を non-goal として文書化

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -31,14 +31,30 @@
 - Turso/libSQL adapter: `tursoAdapter(client)` from `@nanokajs/core/turso`
 - CLI scaffolder package: `create-nanoka-app`
 
-## 未実装として残す
+## 未実装として残す（将来候補）
 
-- Relations: `t.hasMany()` / `t.belongsTo()` — [#14](https://github.com/nanokajs/nanoka/issues/14)
 - Typed query helper: `User.where(f => eq(f.email, x)).limit(10)` など — [#15](https://github.com/nanokajs/nanoka/issues/15)
 - VSCode extension — [#16](https://github.com/nanokajs/nanoka/issues/16)
 - Codex / Claude Code plugin — [#17](https://github.com/nanokajs/nanoka/issues/17)
 - `findMany` offset 上限 — [#18](https://github.com/nanokajs/nanoka/issues/18)
-- Auth / full-stack React / Drizzle replacement DSL は引き続き全 Phase 外
+
+## Non-goal（全 Phase 外）
+
+Relations (`t.hasMany()` / `t.belongsTo()`) / Auth / full-stack React / Drizzle replacement DSL は実装しない。
+
+### Relations を non-goal とする根拠
+
+- cascade / N+1 / join 型推論は Drizzle replacement DSL に最も寄りやすい領域であり、「Drizzle の複雑な query DSL を再発明しない」方針と直接抵触する
+- `app.db` の `innerJoin` / `leftJoin` (escape hatch) で代替可能（README に例あり）
+- field policy / inputSchema で達成した「80% automatic, 20% explicit」バランスを崩す
+- 1.0.0 stable surface の必須条件に含まれていない
+
+### 再検討トリガー（永久 non-goal ではない）
+
+以下が同時に満たされた場合のみ新規 Issue を起票して再検討する（#14 の reopen ではなく新規）:
+
+- ユーザーから「`app.db` 手書き Drizzle では足りない」具体的ユースケースが複数集まる
+- cascade / N+1 / join 型推論を DSL 再発明なしに収めるパターンが先行 OSS で確立する
 
 ## 運用・リスク追跡
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -177,7 +177,7 @@ const result = await app.db
 - 複雑なSQLをDSLですべて表現しない（素のDrizzleで書く）
 - マイグレーションを自動実行しない
 - D1以外のDBをMVP段階で完全サポートしない
-- relationをMVPに含めない（Phase 2以降、手書きDrizzleで対応）
+- relationは引き続き non-goal（手書きDrizzleで対応）
 - フィールドアクセサAPIをMVPに含めない（Phase 2以降）
 
 > **成長戦略**: 薄いラッパーとして始め、使われたらフレームワークに育てる。スコープを広げるタイミングはユーザーの声が判断基準。名乗るのは後でいい。
@@ -203,7 +203,7 @@ const result = await app.db
 - エラーハンドリング: Honoの `HTTPException` に乗る。Nanokaは独自エラー型を持たない
 - transaction: D1のbatch APIをそのまま公開。独自抽象は持たない
 
-> **Phase 1時点のrelationについて**: `t.hasMany()` / `t.belongsTo()` はMVPに含めない。リレーションが必要な場合は素のDrizzleで書く。cascade・N+1・join型推論の設計負荷はPhase 2以降で向き合う。
+> **relationについて**: `t.hasMany()` / `t.belongsTo()` は non-goal と決定（Issue #14）。cascade・N+1・join型推論の設計負荷が高く Drizzle 再発明に寄るため、引き続き手書き Drizzle（`app.db`）で対応する。
 
 ### Phase 1.5 — 公開運用基盤
 - [ ] README onboarding parity CI（公開 tarball / 最小 scaffold で `tsc --noEmit` と `drizzle-kit generate` を検証）
@@ -297,7 +297,7 @@ relation / Turso・libSQL adapter / route-level OpenAPI / `create-nanoka-app` / 
 - [x] CLIスキャフォールダ: `create-nanoka-app`
 
 #### 次に残っている設計候補
-- [ ] リレーション定義（`t.hasMany()` / `t.belongsTo()`）※cascade/N+1/joinの型推論を含む重い作業
+- [x] リレーション定義（`t.hasMany()` / `t.belongsTo()`）— 採用しないと決定（Issue #14 参照）
 - [ ] 型安全なクエリビルダー（`User.where(f => eq(f.email, x)).limit(10)`）※Drizzle再発明に寄りやすいため優先度を下げる
 - [ ] VSCode拡張（モデル定義からの補完）
 - [ ] Claude Code / Codex プラグイン（モデル定義・ルート生成・migration手順の補助）

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -324,6 +324,8 @@ const result = await app.db
   .innerJoin(Post.table, eq(User.table.id, Post.table.userId))
 ```
 
+For relations and N+1 prevention, use `app.db` with Drizzle's `innerJoin` / `leftJoin` directly — this is the recommended long-term approach.
+
 `User.table` is the underlying Drizzle table. Combine with `eq()`, `lt()`, `and()`, `or()` from `drizzle-orm` for complex conditions. SQL injection is prevented by Drizzle's parametrized bindings.
 
 ### `app.batch()` — D1 batch API directly
@@ -405,11 +407,10 @@ Route-level OpenAPI is available via explicit route metadata: `app.openapi(metad
 
 The following features remain planned for later 1.x releases:
 
-- **Relations**: `t.hasMany()` / `t.belongsTo()` with cascade and N+1 query support
 - **Typed query helper**: optional query ergonomics without reimplementing Drizzle
 - **VSCode extension**: schema autocomplete and diagnostics
 
-For complex joins in the meantime, use raw Drizzle via `app.db`. The escape hatch is always open.
+For complex joins, use raw Drizzle via `app.db`. The escape hatch is always open.
 
 ## Workspace structure (for contributors)
 


### PR DESCRIPTION
## Summary

- `t.hasMany()` / `t.belongsTo()` を non-goal として各ドキュメントに明文化
- 「未実装候補」から「全 Phase 外（non-goal）」へ分類変更
- 採用しない根拠と将来の再検討トリガーを `docs/implementation-status.md` に集約

## 変更内容

- `docs/implementation-status.md`: 「未実装として残す（将来候補）」と「Non-goal（全 Phase 外）」を独立セクションに分離。Relations の根拠・再検討トリガーを記載
- `docs/nanoka.md`: 「Phase 2以降で向き合う」を削除し non-goal 決定を明記（2 箇所）
- `packages/nanoka/README.md`: Roadmap から relations 削除、escape hatch に `app.db` 推奨を追記

コード・公開 API の変更なし。バージョンバンプ不要。

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)