### PR TITLE
docs: typed query helper を non-goal として文書化 (#15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ Phase 2後半 and Phase 3 became partially mixed during implementation. Treat th
 
 These remain unimplemented or intentionally out of scope. If a task appears to require one of them, confirm scope before expanding the public API:
 
-- Relations: `t.hasMany()`, `t.belongsTo()`.
-- Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`.
+- Relations: `t.hasMany()`, `t.belongsTo()`. — non-goal, Issue #14
+- Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`. — non-goal, Issue #15
 - VSCode extension / Codex or Claude Code plugin.
 - Auth, full-stack React, or a complex query DSL that replaces Drizzle.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@ Phase 2後半 and Phase 3 became partially mixed during implementation. Treat th
 
 These remain unimplemented or intentionally out of scope. If a task appears to require one of them, confirm scope before expanding the public API:
 
-- Relations: `t.hasMany()`, `t.belongsTo()`.
-- Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`.
+- Relations: `t.hasMany()`, `t.belongsTo()`. — non-goal, Issue #14
+- Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`. — non-goal, Issue #15
 - VSCode extension / Codex or Claude Code plugin.
 - Auth, full-stack React, or a complex query DSL that replaces Drizzle.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Implemented:
 Still pending or intentionally out of scope:
 
 - Relations (`t.hasMany()` / `t.belongsTo()`)
-- Typed query helper (`User.where(f => eq(f.email, x)).limit(10)`)
 - VSCode extension / Codex or Claude Code plugin
 - Auth, full-stack React, or a query DSL that replaces Drizzle
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -33,7 +33,6 @@
 
 ## 未実装として残す（将来候補）
 
-- Typed query helper: `User.where(f => eq(f.email, x)).limit(10)` など — [#15](https://github.com/nanokajs/nanoka/issues/15)
 - VSCode extension — [#16](https://github.com/nanokajs/nanoka/issues/16)
 - Codex / Claude Code plugin — [#17](https://github.com/nanokajs/nanoka/issues/17)
 - `findMany` offset 上限 — [#18](https://github.com/nanokajs/nanoka/issues/18)
@@ -49,12 +48,28 @@ Relations (`t.hasMany()` / `t.belongsTo()`) / Auth / full-stack React / Drizzle 
 - field policy / inputSchema で達成した「80% automatic, 20% explicit」バランスを崩す
 - 1.0.0 stable surface の必須条件に含まれていない
 
-### 再検討トリガー（永久 non-goal ではない）
+### Typed query helper を non-goal とする根拠
+
+- `findOne` / `update` / `delete` は既に `Where<Fields>`（等価 AND）を受け付けており、単純なルックアップは shipped
+- `User.where(f => eq(...))` 形は `and / or / inArray / lt / gt / like` まで広がり、Drizzle replacement DSL に直結する
+- 等価 AND のみの最小 API（`findMany({ where: { email } })`）は `OR` / 範囲 / `LIKE` の瞬間に `app.db` が必要になり「半端な抽象」になる
+- チェーン形（`User.where(...).limit(10)`）は `limit` 呼び忘れを型で強制しづらく、`findMany` の limit 必須安全方針を弱める
+- `app.db.select().from(User.table).where(eq(...)).limit(10)` は 1 行で書け、README で推奨済み（escape hatch）
+
+### 再検討トリガー（Relations — 永久 non-goal ではない）
 
 以下が同時に満たされた場合のみ新規 Issue を起票して再検討する（#14 の reopen ではなく新規）:
 
 - ユーザーから「`app.db` 手書き Drizzle では足りない」具体的ユースケースが複数集まる
 - cascade / N+1 / join 型推論を DSL 再発明なしに収めるパターンが先行 OSS で確立する
+
+### 再検討トリガー（Typed query helper — 永久 non-goal ではない）
+
+以下が同時に満たされた場合のみ新規 Issue を起票して再検討する（#15 の reopen ではなく新規）:
+
+- ユーザーから「`app.db` 手書き Drizzle では足りない」具体的ユースケースが複数集まる
+- `findMany` の等価 AND ユースケース（管理画面の単純フィルタ等）が 1.x 利用者の主流要望として現れる
+- `limit` 必須の安全方針を壊さない API 形が先行 OSS で確立する
 
 ## 運用・リスク追跡
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -114,10 +114,6 @@ User.validator('json', { partial: true })
 // Phase 2：schema / validator のフィールドアクセサ形式
 User.schema({ pick: (f) => [f.name, f.emial] })
 //                                   ^^^^^^ Type error: 'emial' does not exist
-
-// Phase 2後半以降の候補：クエリ側アクセサ
-User.where({ email: 'foo@example.com' })           // MVP（オブジェクト形式）
-User.where(f => eq(f.email, 'foo@example.com'))    // 候補（Drizzle再発明に寄りやすいため後回し）
 ```
 
 内部の `f` はProxyではなく `as const` オブジェクト。ランタイムコストはゼロ。
@@ -178,6 +174,7 @@ const result = await app.db
 - マイグレーションを自動実行しない
 - D1以外のDBをMVP段階で完全サポートしない
 - relationは引き続き non-goal（手書きDrizzleで対応）
+- 型安全なクエリビルダー（`User.where(...)` / `User.where(f => eq(...))`）— 採用しないと決定（Issue #15 参照）
 - フィールドアクセサAPIをMVPに含めない（Phase 2以降）
 
 > **成長戦略**: 薄いラッパーとして始め、使われたらフレームワークに育てる。スコープを広げるタイミングはユーザーの声が判断基準。名乗るのは後でいい。
@@ -298,7 +295,7 @@ relation / Turso・libSQL adapter / route-level OpenAPI / `create-nanoka-app` / 
 
 #### 次に残っている設計候補
 - [x] リレーション定義（`t.hasMany()` / `t.belongsTo()`）— 採用しないと決定（Issue #14 参照）
-- [ ] 型安全なクエリビルダー（`User.where(f => eq(f.email, x)).limit(10)`）※Drizzle再発明に寄りやすいため優先度を下げる
+- [x] 型安全なクエリビルダー（`User.where(f => eq(f.email, x)).limit(10)`）— 採用しないと決定（Issue #15 参照）
 - [ ] VSCode拡張（モデル定義からの補完）
 - [ ] Claude Code / Codex プラグイン（モデル定義・ルート生成・migration手順の補助）
 - [ ] OSSコミュニティ整備

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -241,7 +241,6 @@ pnpm exec drizzle-kit migrate
 
 This example does not include:
 - **Relations** (hasMany, belongsTo, foreign keys) → future 1.x
-- **Typed query helper** (`User.where(f => eq(f.email, 'x'))`) → future 1.x candidate
 - **Authentication** (JWT, OAuth, etc.) → Out of scope
 
 The focus of this example is a working end-to-end flow: model → schema → migrations → type-safe CRUD API → OpenAPI docs.

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -407,7 +407,6 @@ Route-level OpenAPI is available via explicit route metadata: `app.openapi(metad
 
 The following features remain planned for later 1.x releases:
 
-- **Typed query helper**: optional query ergonomics without reimplementing Drizzle
 - **VSCode extension**: schema autocomplete and diagnostics
 
 For complex joins, use raw Drizzle via `app.db`. The escape hatch is always open.

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",


### PR DESCRIPTION
## Summary

- `User.where(...)` 系 API を採用しないと決定し、その根拠・比較・再検討トリガーを docs に永続化
- Relations (#14) と同じ「Drizzle replacement DSL を再発明しない」方針の延長線上に位置付け
- 既存の `findOne` / `update` / `delete` の `Where<Fields>` と `app.db` escape hatch で 80% のユースケースはカバー済みであることを根拠として明記

## Changed files

- `docs/implementation-status.md` — `#15` を将来候補から削除、Non-goal 根拠ブロック・再検討トリガー追加
- `docs/nanoka.md` — 「やらないこと」リスト・「設計候補」更新、候補コードブロック削除
- `README.md` / `packages/nanoka/README.md` / `examples/basic/README.md` — Typed query helper の記述を削除
- `CLAUDE.md` / `AGENTS.md` — non-goal 注釈追記
- `packages/nanoka/package.json` / `packages/create-nanoka-app/package.json` — 1.0.3 → 1.0.4 (patch bump)

## Test plan

- [x] ドキュメント変更のみ（コード追加なし）
- [x] `pnpm -C packages/nanoka build` 成功
- [x] `pnpm lint` — 既存 warning のみ（今回の変更で新規追加なし）

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)