### PR TITLE
docs: VSCode extension を non-goal として文書化 (#16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ These remain unimplemented or intentionally out of scope. If a task appears to r
 
 - Relations: `t.hasMany()`, `t.belongsTo()`. — non-goal, Issue #14
 - Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`. — non-goal, Issue #15
-- VSCode extension / Codex or Claude Code plugin.
+- Codex or Claude Code plugin.
 - Auth, full-stack React, or a complex query DSL that replaces Drizzle.
 
 The schema / validator field-accessor API already exists for `{ pick: f => [f.name] }` and `{ omit: f => [f.passwordHash] }`. Keep its `f` object `as const`, not a Proxy. Runtime cost must remain zero.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ These remain unimplemented or intentionally out of scope. If a task appears to r
 
 - Relations: `t.hasMany()`, `t.belongsTo()`. — non-goal, Issue #14
 - Typed query helper: `User.where(f => eq(f.email, x)).limit(10)`. — non-goal, Issue #15
-- VSCode extension / Codex or Claude Code plugin.
+- Codex or Claude Code plugin.
 - Auth, full-stack React, or a complex query DSL that replaces Drizzle.
 
 The schema / validator field-accessor API already exists for `{ pick: f => [f.name] }` and `{ omit: f => [f.passwordHash] }`. Keep its `f` object `as const`, not a Proxy. Runtime cost must remain zero.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Implemented:
 Still pending or intentionally out of scope:
 
 - Relations (`t.hasMany()` / `t.belongsTo()`)
-- VSCode extension / Codex or Claude Code plugin
+- Codex or Claude Code plugin
 - Auth, full-stack React, or a query DSL that replaces Drizzle
 
 ## Development

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -135,7 +135,7 @@ relation / Turso・libSQL adapter / route-level OpenAPI / `create-nanoka-app` / 
 - **Relations** (`t.hasMany()` / `t.belongsTo()`)
 - **型安全なクエリビルダー** (`User.where(f => eq(f.email, x)).limit(10)`)
   - Drizzle 再発明に寄りやすいため優先度を下げる。
-- **VSCode 拡張 / Codex プラグイン**
+- **Codex プラグイン**
 
 ### 3.6 `findMany` の `offset` 上限導入（DoS 緩和）
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -33,7 +33,6 @@
 
 ## 未実装として残す（将来候補）
 
-- VSCode extension — [#16](https://github.com/nanokajs/nanoka/issues/16)
 - Codex / Claude Code plugin — [#17](https://github.com/nanokajs/nanoka/issues/17)
 - `findMany` offset 上限 — [#18](https://github.com/nanokajs/nanoka/issues/18)
 
@@ -70,6 +69,20 @@ Relations (`t.hasMany()` / `t.belongsTo()`) / Auth / full-stack React / Drizzle 
 - ユーザーから「`app.db` 手書き Drizzle では足りない」具体的ユースケースが複数集まる
 - `findMany` の等価 AND ユースケース（管理画面の単純フィルタ等）が 1.x 利用者の主流要望として現れる
 - `limit` 必須の安全方針を壊さない API 形が先行 OSS で確立する
+
+### VSCode extension を non-goal とする根拠
+
+- core API の価値（model DSL → schema/validator 派生・OpenAPI・adapters）は TypeScript 言語サーバと既存 Hono / Drizzle / Zod エコシステムで完結しており、editor integration なしで「80% automatic, 20% explicit」を実現できる
+- VSCode 拡張の候補機能は既存ツールで代替可能: DSL 補完 → TypeScript 言語サーバ、schema generation → `nanoka generate` CLI、docs link → README / Swagger UI、diagnostics → `tsc --noEmit` と Biome
+- Marketplace publish・VSCode API メジャーアップ追従・Cursor/Windsurf などの派生 IDE 対応など、維持コストが core 価値に対して大きい
+- `#14`（Relations）/ `#15`（Typed query helper）と同じ「核心価値でないものを抱え込まない」方針の延長
+
+### 再検討トリガー（VSCode extension — 永久 non-goal ではない）
+
+以下が同時に満たされた場合のみ新規 Issue を起票して再検討する（#16 の reopen ではなく新規）:
+
+- ユーザーから「TypeScript 言語サーバの補完では足りない」具体的ユースケースが複数集まる（例: `pick`/`omit` の field accessor が IDE 上で見えづらい等）
+- Nanoka 専用の lint/diagnostic（`extend()` で `serverOnly` フィールドを再注入した場合の警告等）が ESLint plugin では実装困難であることが判明する
 
 ## 運用・リスク追跡
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -175,6 +175,7 @@ const result = await app.db
 - D1以外のDBをMVP段階で完全サポートしない
 - relationは引き続き non-goal（手書きDrizzleで対応）
 - 型安全なクエリビルダー（`User.where(...)` / `User.where(f => eq(...))`）— 採用しないと決定（Issue #15 参照）
+- VSCode extension（TypeScript 言語サーバ + Biome + nanoka generate で十分。Issue #16 参照）
 - フィールドアクセサAPIをMVPに含めない（Phase 2以降）
 
 > **成長戦略**: 薄いラッパーとして始め、使われたらフレームワークに育てる。スコープを広げるタイミングはユーザーの声が判断基準。名乗るのは後でいい。
@@ -296,7 +297,7 @@ relation / Turso・libSQL adapter / route-level OpenAPI / `create-nanoka-app` / 
 #### 次に残っている設計候補
 - [x] リレーション定義（`t.hasMany()` / `t.belongsTo()`）— 採用しないと決定（Issue #14 参照）
 - [x] 型安全なクエリビルダー（`User.where(f => eq(f.email, x)).limit(10)`）— 採用しないと決定（Issue #15 参照）
-- [ ] VSCode拡張（モデル定義からの補完）
+- [x] VSCode拡張（モデル定義からの補完）— 採用しないと決定（Issue #16 参照）
 - [ ] Claude Code / Codex プラグイン（モデル定義・ルート生成・migration手順の補助）
 - [ ] OSSコミュニティ整備
 

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -403,12 +403,6 @@ The runtime source of truth for validation remains the Zod schema returned by `i
 
 Route-level OpenAPI is available via explicit route metadata: `app.openapi(metadata)` registers operation details, and `app.generateOpenAPISpec(options)` builds the OpenAPI 3.1 document. Swagger UI is available through `swaggerUI({ url, title? })`.
 
-## Roadmap (1.x)
-
-The following features remain planned for later 1.x releases:
-
-- **VSCode extension**: schema autocomplete and diagnostics
-
 For complex joins, use raw Drizzle via `app.db`. The escape hatch is always open.
 
 ## Workspace structure (for contributors)

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",


### PR DESCRIPTION
## Summary

- VSCode extension を non-goal として確定し、判断根拠と再検討トリガーを docs に記録
- #14 / #15（Relations / Typed query helper）と同じ形式で `docs/implementation-status.md` に追記
- 関連する README / CLAUDE.md / AGENTS.md の roadmap 記述を削除し、ドキュメント間の整合を取った

## Changed files

- `docs/implementation-status.md` — Non-goal セクションに根拠（bullet 4本）と再検討トリガー（2本）を追加
- `docs/nanoka.md` — 「Nanokaがやらないこと」に VSCode extension を追加、設計候補リストを更新
- `docs/backlog.md` — 「未実装のまま残す候補」から VSCode 拡張を削除
- `README.md` / `packages/nanoka/README.md` — VSCode extension の roadmap 記述を削除
- `CLAUDE.md` / `AGENTS.md` — VSCode extension の記述を削除（Codex / Claude Code plugin のみ残す）
- `packages/nanoka/package.json` / `packages/create-nanoka-app/package.json` — 1.0.4 → 1.0.5（patch bump）

## Test plan

- [x] `pnpm -C packages/nanoka build` 成功
- [x] `pnpm lint` 新規警告なし
- [x] コア API（`packages/nanoka/src/`）への変更なし

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)