### PR TITLE
feat: nanoka generate にマイグレーション統合フラグを追加 (v1.1.0)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -30,6 +30,7 @@
 - Swagger UI middleware: `swaggerUI({ url, title? })`
 - Turso/libSQL adapter: `tursoAdapter(client)` from `@nanokajs/core/turso`
 - CLI scaffolder package: `create-nanoka-app`
+- Unified migration workflow: `nanoka generate --apply --db <name>` — [#41](https://github.com/nanokajs/nanoka/issues/41)
 
 ### AI coding support
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -136,8 +136,14 @@ const f = { id: 'id', name: 'name', email: 'email' } as const
 ```
 # Nanokaがやること
 nanoka generate        # モデル定義 → Drizzleスキーマファイルを生成
+                       # drizzle.config.ts が存在すれば drizzle-kit generate も自動実行
 
-# 既存ツールに委ねること
+# ワンコマンドで全パイプライン実行（--apply フラグ）
+nanoka generate --apply --db <DATABASE>
+#   → schema 生成 + drizzle-kit generate + wrangler d1 migrations apply --local
+# リモートに適用する場合: nanoka generate --apply --db <DATABASE> --remote
+
+# 既存ツールに委ねること（--apply を使わない場合）
 drizzle-kit generate   # スキーマ差分からSQLを生成
 wrangler d1 migrations apply --local / --remote  # 適用
 ```

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -22,25 +22,19 @@ This example demonstrates the full workflow from model definition to working API
    pnpm -C packages/nanoka build
    ```
 
-3. **Generate Drizzle schema** (from user model)
+3. **Generate schema and apply migrations** (unified pipeline)
    ```bash
-   pnpm -C examples/basic generate
+   pnpm -C examples/basic generate:all
    ```
-   ✓ Creates `drizzle/schema.ts` from `src/models/user.ts`
+   ✓ Runs `nanoka generate` (creates `drizzle/schema.ts`) + `drizzle-kit generate` (SQL migrations) + `wrangler d1 migrations apply --local` in sequence.
 
-4. **Generate SQL migrations**
+   Alternatively, run each step individually:
    ```bash
-   pnpm -C examples/basic db:generate
+   pnpm -C examples/basic generate        # creates drizzle/schema.ts + runs drizzle-kit generate
+   pnpm -C examples/basic db:migrate:local  # applies migrations to local D1
    ```
-   ✓ Creates `drizzle/migrations/0000_*.sql` from Drizzle schema
 
-5. **Apply migrations locally**
-   ```bash
-   pnpm -C examples/basic db:migrate:local
-   ```
-   ✓ Creates SQLite database in `.wrangler/state/v3/d1/`
-
-6. **Start development server**
+4. **Start development server**
    ```bash
    pnpm -C examples/basic dev
    ```

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "generate": "nanoka generate",
+    "generate:all": "nanoka generate --apply --db nanoka-basic",
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply nanoka-basic --local",
     "db:migrate:remote": "wrangler d1 migrations apply nanoka-basic --remote",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,14 +25,32 @@ Add to `tsconfig.json` so Cloudflare Workers types resolve as ambient:
 
 ## Migration flow
 
-Nanoka has no custom migration engine. The flow is:
+Nanoka has no custom migration engine. SQL generation and application stay with drizzle-kit and wrangler.
+
+**One-command flow (recommended):**
+
+```bash
+# drizzle.config.ts が存在すれば drizzle-kit generate まで自動実行
+npx nanoka generate
+
+# schema 生成 → drizzle-kit generate → wrangler apply を一括実行
+npx nanoka generate --apply --db <DATABASE>
+
+# 本番 D1 への適用
+npx nanoka generate --apply --db <DATABASE> --remote
+
+# drizzle-kit の自動実行をスキップしたい場合
+npx nanoka generate --no-migrate
+```
+
+**Manual step-by-step flow:**
 
 1. Write model definitions (e.g., `postFields` in `src/models/posts.ts`)
-2. Create `nanoka.config.ts` and run `npx nanoka generate` → produces `drizzle/schema.ts` (Drizzle schema code, not SQL)
-3. Create `drizzle.config.ts` and run `npx drizzle-kit generate` → produces `drizzle/migrations/*.sql` (SQL diffs)
+2. Create `nanoka.config.ts` and run `npx nanoka generate` → produces `drizzle/schema.ts`
+3. Create `drizzle.config.ts` and run `npx drizzle-kit generate` → produces `drizzle/migrations/*.sql`
 4. Run `wrangler d1 migrations apply <DATABASE> --local` → applies migrations to D1
 
-Nanoka does not generate SQL or apply migrations. That responsibility stays with drizzle-kit and wrangler.
+`nanoka generate` automatically runs `drizzle-kit generate` when `drizzle.config.ts` is detected. SQL generation and migration application are delegated to drizzle-kit and wrangler respectively — Nanoka does not reimplement them.
 
 ## Core API
 
@@ -543,13 +561,13 @@ const results = await app.batch([
 ])
 ```
 
-**Do not use `nanoka generate` for migration logic**
+**`nanoka generate` does not produce SQL itself — it delegates to drizzle-kit**
 
 ```bash
-# ❌ nanoka generate does not produce SQL
-npx nanoka generate
+# ✅ One-command full pipeline (drizzle.config.ts 検出時に drizzle-kit も自動実行)
+npx nanoka generate --apply --db <DB>
 
-# ✅ Full flow
+# ✅ Manual step-by-step (同等の結果)
 npx nanoka generate                    # → drizzle/schema.ts
 npx drizzle-kit generate              # → drizzle/migrations/*.sql
 wrangler d1 migrations apply <DB>    # → apply to D1

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/create-nanoka-app/templates/default/README.md
+++ b/packages/create-nanoka-app/templates/default/README.md
@@ -7,6 +7,13 @@ A Hono + Drizzle + D1 project scaffolded with `create-nanoka-app`.
 ```bash
 pnpm install
 pnpm exec nanoka generate
-pnpm exec drizzle-kit generate
 pnpm dev
+```
+
+`pnpm exec nanoka generate` generates the Drizzle schema from your model definitions. If a `drizzle.config.ts` is present in your project root, it also automatically runs `drizzle-kit generate` to produce SQL migration files.
+
+To apply migrations to your local D1 database in one step:
+
+```bash
+pnpm exec nanoka generate --apply --db <DATABASE_NAME>
 ```

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `@nanokajs/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] — 2026-05-04
+
+### Added
+
+- Unified migration workflow: `nanoka generate` now automatically runs `drizzle-kit generate` when `drizzle.config.ts` (or `.js` / `.mjs`) is detected in the working directory.
+- `--apply --db <name>` flag: runs the full pipeline (schema generation → `drizzle-kit generate` → `wrangler d1 migrations apply --local`) in one command.
+- `--remote` flag: used with `--apply` to apply migrations remotely instead of locally.
+- `--no-migrate` flag: skips `drizzle-kit generate`, running schema generation only.
+- `--package-manager <pm>` flag: controls how sub-commands are invoked (`npx` default, `pnpm`, `npm`, `yarn`, `bun`).
+- `NanokaConfig.migrate` field: optional config for `drizzleConfig`, `database`, and `packageManager` — can supply `--db` and `--package-manager` defaults via `nanoka.config.ts`.
+
 ## [1.0.2] — 2026-05-03
 
 ### Added

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -133,8 +133,21 @@ Peer dependency ranges: `hono ^4.0.0`, `drizzle-orm ^0.45.0`, `zod ^3.23.0 || ^4
    })
    ```
 
-   Then:
+   **Option A: unified pipeline (recommended)**
    ```bash
+   npx nanoka generate --apply --db <DATABASE>
+   ```
+   When `drizzle.config.ts` is present, `nanoka generate` automatically runs `drizzle-kit generate`. Adding `--apply --db <DATABASE>` also runs `wrangler d1 migrations apply --local`.
+
+   **Option B: step by step**
+   ```bash
+   npx nanoka generate           # schema generation + drizzle-kit generate (auto when drizzle.config.ts exists)
+   npx wrangler d1 migrations apply <DATABASE> --local
+   ```
+
+   **Option C: schema generation only**
+   ```bash
+   npx nanoka generate --no-migrate   # skips drizzle-kit
    npx drizzle-kit generate
    npx wrangler d1 migrations apply <DATABASE> --local
    ```

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/cli/__tests__/cli.test.ts
+++ b/packages/nanoka/src/cli/__tests__/cli.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { main } from '../index'
+
+vi.mock('../run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../run')>()
+  return {
+    ...actual,
+    runDrizzleKitGenerate: vi.fn().mockResolvedValue(undefined),
+    runWranglerApply: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+import * as runModule from '../run'
 
 describe('CLI', () => {
   it('shows help with no arguments', async () => {
@@ -25,5 +36,158 @@ describe('CLI', () => {
   it('returns error with missing --output if config.output is not defined', async () => {
     const exitCode = await main(['generate', '--config', '/tmp/fake.ts'])
     expect(exitCode).toBe(1)
+  })
+})
+
+describe('CLI generate with migrate flags', () => {
+  const runDrizzleKitGenerate = vi.mocked(runModule.runDrizzleKitGenerate)
+  const runWranglerApply = vi.mocked(runModule.runWranglerApply)
+
+  let originalCwd: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    originalCwd = process.cwd()
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    vi.restoreAllMocks()
+  })
+
+  it('calls runDrizzleKitGenerate when drizzle.config.ts exists', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+    const resolvedCwd = process.cwd()
+
+    const exitCode = await main(['generate'])
+    expect(exitCode).toBe(0)
+    expect(runDrizzleKitGenerate).toHaveBeenCalledOnce()
+    expect(runDrizzleKitGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: resolvedCwd }),
+    )
+  })
+
+  it('does not call runDrizzleKitGenerate with --no-migrate', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--no-migrate'])
+    expect(exitCode).toBe(0)
+    expect(runDrizzleKitGenerate).not.toHaveBeenCalled()
+  })
+
+  it('calls both runDrizzleKitGenerate and runWranglerApply with --apply --db foo', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--apply', '--db', 'foo'])
+    expect(exitCode).toBe(0)
+    expect(runDrizzleKitGenerate).toHaveBeenCalledOnce()
+    expect(runWranglerApply).toHaveBeenCalledOnce()
+    expect(runWranglerApply).toHaveBeenCalledWith(
+      expect.objectContaining({ db: 'foo', remote: false }),
+    )
+  })
+
+  it('returns exit 1 when --db contains invalid characters (argument smuggling)', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--apply', '--db', 'mydb --remote'])
+    expect(exitCode).toBe(1)
+    expect(runWranglerApply).not.toHaveBeenCalled()
+  })
+
+  it('returns exit 1 when --apply given but no --db and no config.migrate.database', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--apply'])
+    expect(exitCode).toBe(1)
+    expect(runWranglerApply).not.toHaveBeenCalled()
+  })
+
+  it('skips runDrizzleKitGenerate but still calls runWranglerApply with --no-migrate --apply --db foo', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--no-migrate', '--apply', '--db', 'foo'])
+    expect(exitCode).toBe(0)
+    expect(runDrizzleKitGenerate).not.toHaveBeenCalled()
+    expect(runWranglerApply).toHaveBeenCalledOnce()
+    expect(runWranglerApply).toHaveBeenCalledWith(expect.objectContaining({ db: 'foo' }))
+  })
+
+  it('passes remote: true to runWranglerApply with --apply --remote', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+
+    const dir = await mkdtemp(join(tmpdir(), 'nanoka-test-'))
+
+    const configContent = `export default { models: [], output: '${dir}/schema.ts' }`
+    await writeFile(join(dir, 'nanoka.config.ts'), configContent)
+    await writeFile(join(dir, 'drizzle.config.ts'), '// drizzle config')
+
+    process.chdir(dir)
+
+    const exitCode = await main(['generate', '--apply', '--db', 'mydb', '--remote'])
+    expect(exitCode).toBe(0)
+    expect(runWranglerApply).toHaveBeenCalledWith(expect.objectContaining({ remote: true }))
   })
 })

--- a/packages/nanoka/src/cli/index.ts
+++ b/packages/nanoka/src/cli/index.ts
@@ -3,26 +3,64 @@ import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { generateDrizzleSchema } from '../codegen/generate'
 import { loadConfig } from './load-config'
+import { runDrizzleKitGenerate, runWranglerApply, validateDbName } from './run'
+
+async function findDrizzleConfig(cwd: string): Promise<string | undefined> {
+  const candidates = ['drizzle.config.ts', 'drizzle.config.js', 'drizzle.config.mjs']
+  for (const name of candidates) {
+    try {
+      await fs.access(resolve(cwd, name))
+      return resolve(cwd, name)
+    } catch {
+      // not found, try next
+    }
+  }
+  return undefined
+}
 
 async function main(args: string[]): Promise<number> {
   try {
     if (args.length === 0 || args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
-      console.log('Usage: nanoka generate [--config <path>] [--output <path>]')
+      console.log(
+        'Usage: nanoka generate [--config <path>] [--output <path>] [--no-migrate] [--apply --db <name>] [--remote] [--package-manager <pm>]',
+      )
       console.log('')
       console.log('Options:')
-      console.log('  --config <path>   Path to nanoka.config.ts (default: ./nanoka.config.ts)')
-      console.log('  --output <path>   Output file path (overrides config.output)')
+      console.log(
+        '  --config <path>           Path to nanoka.config.ts (default: ./nanoka.config.ts)',
+      )
+      console.log('  --output <path>           Output file path (overrides config.output)')
+      console.log('  --no-migrate              Skip drizzle-kit generate (schema generation only)')
+      console.log(
+        '  --apply                   Run wrangler d1 migrations apply after drizzle-kit generate',
+      )
+      console.log(
+        '  --db <name>               D1 database name for wrangler (required with --apply)',
+      )
+      console.log(
+        '  --remote                  Apply migrations to remote instead of local (used with --apply)',
+      )
+      console.log(
+        '  --package-manager <pm>    Package manager to use: npx (default), pnpm, npm, yarn, bun',
+      )
       return 0
     }
 
     if (args[0] !== 'generate') {
       console.error(`Error: unknown command '${args[0]}'`)
-      console.error('Usage: nanoka generate [--config <path>] [--output <path>]')
+      console.error(
+        'Usage: nanoka generate [--config <path>] [--output <path>] [--no-migrate] [--apply --db <name>] [--remote] [--package-manager <pm>]',
+      )
       return 1
     }
 
     let configPath: string = './nanoka.config.ts'
     let outputPath: string | undefined
+    let noMigrate = false
+    let apply = false
+    let dbName: string | undefined
+    let remote = false
+    let packageManager: string = 'npx'
 
     let i = 1
     while (i < args.length) {
@@ -34,17 +72,44 @@ async function main(args: string[]): Promise<number> {
         const next = args[i + 1]
         if (next !== undefined) outputPath = next
         i += 2
+      } else if (args[i] === '--no-migrate') {
+        noMigrate = true
+        i += 1
+      } else if (args[i] === '--apply') {
+        apply = true
+        i += 1
+      } else if (args[i] === '--db' && i + 1 < args.length) {
+        const next = args[i + 1]
+        if (next !== undefined) dbName = next
+        i += 2
+      } else if (args[i] === '--remote') {
+        remote = true
+        i += 1
+      } else if (args[i] === '--package-manager' && i + 1 < args.length) {
+        const next = args[i + 1]
+        if (next !== undefined) {
+          const validPms = ['npx', 'pnpm', 'npm', 'yarn', 'bun']
+          if (!validPms.includes(next)) {
+            console.error(
+              `Error: unsupported package manager '${next}'. Use one of: ${validPms.join(', ')}`,
+            )
+            return 1
+          }
+          packageManager = next
+        }
+        i += 2
       } else {
         console.error(`Error: unknown option '${args[i]}'`)
         return 1
       }
     }
 
-    const absoluteConfigPath = resolve(process.cwd(), configPath)
+    const cwd = process.cwd()
+    const absoluteConfigPath = resolve(cwd, configPath)
     const config = await loadConfig(absoluteConfigPath)
 
     const finalOutputPath = outputPath ?? config.output ?? './drizzle/schema.ts'
-    const absoluteOutputPath = resolve(process.cwd(), finalOutputPath)
+    const absoluteOutputPath = resolve(cwd, finalOutputPath)
 
     const schema = generateDrizzleSchema(config.models)
 
@@ -52,6 +117,44 @@ async function main(args: string[]): Promise<number> {
     await fs.writeFile(absoluteOutputPath, schema, 'utf-8')
 
     console.log(`✓ Generated ${absoluteOutputPath}`)
+
+    if (!noMigrate) {
+      const drizzleConfigPath =
+        config.migrate?.drizzleConfig !== undefined
+          ? resolve(cwd, config.migrate.drizzleConfig)
+          : await findDrizzleConfig(cwd)
+
+      if (drizzleConfigPath !== undefined) {
+        const pm = config.migrate?.packageManager ?? packageManager
+        console.log('Running drizzle-kit generate...')
+        await runDrizzleKitGenerate({ cwd, configPath: drizzleConfigPath, pm })
+        console.log('✓ drizzle-kit generate completed')
+      } else {
+        console.log('No drizzle.config.ts found, skipping drizzle-kit generate')
+      }
+    }
+
+    if (apply) {
+      const resolvedDb = dbName ?? config.migrate?.database
+      if (resolvedDb === undefined) {
+        console.error(
+          'Error: --db <name> を指定するか nanoka.config.ts の migrate.database に設定してください',
+        )
+        return 1
+      }
+      try {
+        validateDbName(resolvedDb)
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : err}`)
+        return 1
+      }
+
+      const pm = config.migrate?.packageManager ?? packageManager
+      console.log(`Running wrangler d1 migrations apply ${resolvedDb}...`)
+      await runWranglerApply({ cwd, db: resolvedDb, remote, pm })
+      console.log('✓ wrangler d1 migrations apply completed')
+    }
+
     return 0
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/nanoka/src/cli/run.ts
+++ b/packages/nanoka/src/cli/run.ts
@@ -1,0 +1,72 @@
+import { spawn } from 'node:child_process'
+
+const D1_DATABASE_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/
+
+export function validateDbName(db: string): void {
+  if (!D1_DATABASE_NAME_RE.test(db)) {
+    throw new Error(
+      `Invalid D1 database name: "${db}". Only alphanumerics, hyphens, and underscores are allowed (max 64 chars).`,
+    )
+  }
+}
+
+function resolveRunner(pm: string): { cmd: string; prefix: string[] } {
+  switch (pm) {
+    case 'pnpm':
+      return { cmd: 'pnpm', prefix: ['exec'] }
+    case 'npm':
+      return { cmd: 'npm', prefix: ['exec'] }
+    case 'yarn':
+      return { cmd: 'yarn', prefix: ['dlx'] }
+    case 'bun':
+      return { cmd: 'bunx', prefix: [] }
+    case 'npx':
+      return { cmd: 'npx', prefix: [] }
+    default:
+      throw new Error(
+        `Unsupported package manager: "${pm}". Use one of: npx, pnpm, npm, yarn, bun.`,
+      )
+  }
+}
+
+function runProcess(cmd: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', shell: false, cwd })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`Command '${cmd} ${args.join(' ')}' exited with code ${code}`))
+      }
+    })
+    child.on('error', (err) => {
+      reject(new Error(`Failed to spawn '${cmd}': ${err.message}`))
+    })
+  })
+}
+
+export async function runDrizzleKitGenerate(opts: {
+  cwd: string
+  configPath?: string
+  pm: string
+}): Promise<void> {
+  const { cmd, prefix } = resolveRunner(opts.pm)
+  const args = [...prefix, 'drizzle-kit', 'generate']
+  if (opts.configPath) {
+    args.push('--config', opts.configPath)
+  }
+  await runProcess(cmd, args, opts.cwd)
+}
+
+export async function runWranglerApply(opts: {
+  cwd: string
+  db: string
+  remote: boolean
+  pm: string
+}): Promise<void> {
+  validateDbName(opts.db)
+  const { cmd, prefix } = resolveRunner(opts.pm)
+  const args = [...prefix, 'wrangler', 'd1', 'migrations', 'apply', opts.db]
+  args.push(opts.remote ? '--remote' : '--local')
+  await runProcess(cmd, args, opts.cwd)
+}

--- a/packages/nanoka/src/codegen/types.ts
+++ b/packages/nanoka/src/codegen/types.ts
@@ -8,4 +8,9 @@ export interface ModelDef {
 export interface NanokaConfig {
   readonly output?: string | undefined
   readonly models: readonly ModelDef[]
+  readonly migrate?: {
+    readonly drizzleConfig?: string
+    readonly database?: string
+    readonly packageManager?: 'npx' | 'pnpm' | 'npm' | 'yarn' | 'bun'
+  }
 }


### PR DESCRIPTION
## Summary

- `drizzle.config.ts` を検出したとき `nanoka generate` だけで `drizzle-kit generate` まで自動実行
- `nanoka generate --apply --db <name>` で schema 生成 → drizzle-kit generate → `wrangler d1 migrations apply --local` を一括実行
- `--no-migrate` で自動実行をスキップ、`--remote` で本番 D1 に適用
- `--package-manager <npx|pnpm|npm|yarn|bun>` で呼び出し方法を選択可能
- DB 名は `--db` フラグ → `nanoka.config.ts` の `migrate.database` の順で解決
- `validateDbName` による option smuggling 対策（`/^[A-Za-z0-9_-]{1,64}$/`）
- `packageManager` にホワイトリスト外の値を渡すとエラー終了（サイレントフォールバック廃止）

## Breaking changes

なし。`nanoka generate`（フラグなし）の既存動作は `drizzle.config.ts` が存在しない環境では完全互換。

## Test plan

- [ ] `pnpm -C packages/nanoka test:node` — 31 tests passed
- [ ] `pnpm -C packages/nanoka typecheck` — pass
- [ ] `pnpm lint` — errors 0 (warnings 60 は既存コード)
- [ ] `examples/basic` で `pnpm exec nanoka generate` → drizzle-kit generate が自動実行されること（手動確認）
- [ ] `pnpm exec nanoka generate --apply --db nanoka-basic` → wrangler apply まで一括実行（手動確認）

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)