### PR TITLE
feat: route 定義に inline { openapi } を渡せる短縮 API を追加 (v1.2.0)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -31,6 +31,7 @@
 - Turso/libSQL adapter: `tursoAdapter(client)` from `@nanokajs/core/turso`
 - CLI scaffolder package: `create-nanoka-app`
 - Unified migration workflow: `nanoka generate --apply --db <name>` — [#41](https://github.com/nanokajs/nanoka/issues/41)
+- Inline route OpenAPI: `app.post(path, { openapi: {...} }, ...handlers)` — [#38](https://github.com/nanokajs/nanoka/issues/38)
 
 ### AI coding support
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -296,6 +296,7 @@ relation / Turso・libSQL adapter / route-level OpenAPI / `create-nanoka-app` / 
 
 #### 1.x 追加済み（Phase 2 後半 / Phase 3 が混在して実装されたもの）
 - [x] route-level OpenAPI: `app.openapi(metadata)` / `app.generateOpenAPISpec(options)`
+- [x] inline route OpenAPI: `app.post(path, { openapi: {...} }, ...handlers)` — `path` / `method` を省略できる短縮形（Known limitation: `c.req.valid` の型推論が失われる）
 - [x] Swagger UI middleware: `swaggerUI({ url, title? })`
 - [x] Turso / libSQL adapter: `tursoAdapter(client)`（`@nanokajs/core/turso` export）
 - [x] CLIスキャフォールダ: `create-nanoka-app`

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -35,141 +35,149 @@ export default {
       return c.json(body, status)
     })
 
-    // OpenAPI metadata registration
-    app.openapi({
-      path: '/users',
-      method: 'post',
-      summary: 'Create user',
-      requestBody: {
-        required: true,
-        content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
-      },
-      responses: {
-        '201': {
-          description: 'Created user',
-          content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+    // Known limitation: routes using inline { openapi } lose c.req.valid type inference
+    // (H[] variadic overload). Cast explicitly below. Use app.openapi() + separate route
+    // definition if full handler type safety is required.
+
+    // POST /users - Create user
+    app.post(
+      '/users',
+      {
+        openapi: {
+          summary: 'Create user',
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+          },
+          responses: {
+            '201': {
+              description: 'Created user',
+              content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+            },
+            '400': { description: 'Validation error' },
+          },
         },
-        '400': { description: 'Validation error' },
       },
-    })
-    app.openapi({
-      path: '/users',
-      method: 'get',
-      summary: 'List users',
-      responses: {
-        '200': {
-          description: 'List of users',
-          content: {
-            'application/json': {
-              schema: { type: 'array', items: User.toOpenAPISchema('output') },
+      User.validator('json', 'create'),
+      async (c) => {
+        // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
+        const body = (c.req.valid as (target: 'json') => any)('json')
+        const id = crypto.randomUUID()
+        // SECURITY: demo-only — the email is reversible, NEVER use in production.
+        // Replace with a real password hash (bcrypt, argon2, scrypt) or accept a
+        // pre-hashed value from the client and verify the algorithm.
+        const passwordHash = `demo-${body.email}`
+        const createdAt = new Date()
+
+        // app.db 経由の行は policy 未適用（passwordHash を含む完全な DB 行）。必ず User.toResponse() を通すこと。
+        const rows = await app.db
+          .insert(User.table)
+          .values({ ...body, id, passwordHash, createdAt })
+          .returning()
+        const created = rows[0] as import('@nanokajs/core').RowType<typeof User.fields>
+
+        return c.json(User.toResponse(created), 201)
+      },
+    )
+
+    // GET /users - List users
+    app.get(
+      '/users',
+      {
+        openapi: {
+          summary: 'List users',
+          responses: {
+            '200': {
+              description: 'List of users',
+              content: {
+                'application/json': {
+                  schema: { type: 'array', items: User.toOpenAPISchema('output') },
+                },
+              },
             },
           },
         },
       },
-    })
-    app.openapi({
-      path: '/users/:id',
-      method: 'get',
-      summary: 'Get user by ID',
-      params: [
-        { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
-      ],
-      responses: {
-        '200': {
-          description: 'User found',
-          content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
-        },
-        '404': { description: 'User not found' },
+      async (c) => {
+        const querySchema = z.object({
+          limit: z.coerce.number().int().min(1).max(100).default(20),
+          offset: z.coerce.number().int().min(0).default(0),
+        })
+
+        const queryResult = querySchema.safeParse(c.req.query())
+        if (!queryResult.success) {
+          throw new HTTPException(400, { message: 'Invalid query parameters' })
+        }
+
+        const { limit, offset } = queryResult.data
+        const users = await User.findMany({ limit, offset, orderBy: 'id' })
+        const result = z.array(User.outputSchema()).parse(users)
+        return c.json(result)
       },
-    })
-    app.openapi({
-      path: '/users/:id',
-      method: 'patch',
-      summary: 'Update user',
-      params: [
-        { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
-      ],
-      requestBody: {
-        required: true,
-        content: { 'application/json': { schema: User.toOpenAPISchema('update') } },
-      },
-      responses: {
-        '200': {
-          description: 'Updated user',
-          content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
-        },
-        '404': { description: 'User not found' },
-      },
-    })
-    app.openapi({
-      path: '/users/:id',
-      method: 'delete',
-      summary: 'Delete user',
-      params: [
-        { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
-      ],
-      responses: {
-        '204': { description: 'User deleted' },
-        '404': { description: 'User not found' },
-      },
-    })
-
-    // POST /users - Create user
-    app.post('/users', User.validator('json', 'create'), async (c) => {
-      const body = c.req.valid('json')
-      const id = crypto.randomUUID()
-      // SECURITY: demo-only — the email is reversible, NEVER use in production.
-      // Replace with a real password hash (bcrypt, argon2, scrypt) or accept a
-      // pre-hashed value from the client and verify the algorithm.
-      const passwordHash = `demo-${body.email}`
-      const createdAt = new Date()
-
-      // app.db 経由の行は policy 未適用（passwordHash を含む完全な DB 行）。必ず User.toResponse() を通すこと。
-      const rows = await app.db
-        .insert(User.table)
-        .values({ ...body, id, passwordHash, createdAt })
-        .returning()
-      const created = rows[0] as import('@nanokajs/core').RowType<typeof User.fields>
-
-      return c.json(User.toResponse(created), 201)
-    })
-
-    // GET /users - List users
-    app.get('/users', async (c) => {
-      const querySchema = z.object({
-        limit: z.coerce.number().int().min(1).max(100).default(20),
-        offset: z.coerce.number().int().min(0).default(0),
-      })
-
-      const queryResult = querySchema.safeParse(c.req.query())
-      if (!queryResult.success) {
-        throw new HTTPException(400, { message: 'Invalid query parameters' })
-      }
-
-      const { limit, offset } = queryResult.data
-      const users = await User.findMany({ limit, offset, orderBy: 'id' })
-      const result = z.array(User.outputSchema()).parse(users)
-      return c.json(result)
-    })
+    )
 
     // GET /users/:id - Get single user
-    app.get('/users/:id', User.validator('param', { pick: ['id'] }), async (c) => {
-      const { id } = c.req.valid('param')
-      const user = await User.findOne(id)
-      if (!user) {
-        throw new HTTPException(404, { message: 'User not found' })
-      }
-      return c.json(User.toResponse(user))
-    })
+    app.get(
+      '/users/:id',
+      {
+        openapi: {
+          summary: 'Get user by ID',
+          params: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
+          ],
+          responses: {
+            '200': {
+              description: 'User found',
+              content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+            },
+            '404': { description: 'User not found' },
+          },
+        },
+      },
+      User.validator('param', { pick: ['id'] }) as import('hono').MiddlewareHandler,
+      async (c) => {
+        // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
+        const { id } = (c.req.valid as (target: 'param') => any)('param')
+        const user = await User.findOne(id)
+        if (!user) {
+          throw new HTTPException(404, { message: 'User not found' })
+        }
+        return c.json(User.toResponse(user))
+      },
+    )
 
     // PATCH /users/:id - Update user
     app.patch(
       '/users/:id',
-      User.validator('param', { pick: ['id'] }),
-      User.validator('json', { partial: true, pick: ['name', 'email'] }),
+      {
+        openapi: {
+          summary: 'Update user',
+          params: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
+          ],
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: User.toOpenAPISchema('update') } },
+          },
+          responses: {
+            '200': {
+              description: 'Updated user',
+              content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+            },
+            '404': { description: 'User not found' },
+          },
+        },
+      },
+      User.validator('param', { pick: ['id'] }) as import('hono').MiddlewareHandler,
+      User.validator('json', {
+        partial: true,
+        pick: ['name', 'email'],
+      }) as import('hono').MiddlewareHandler,
       async (c) => {
-        const { id } = c.req.valid('param')
-        const body = c.req.valid('json')
+        // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
+        const { id } = (c.req.valid as (target: 'param') => any)('param')
+        // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
+        const body = (c.req.valid as (target: 'json') => any)('json')
         const updated = await User.update(id, body)
         if (!updated) {
           throw new HTTPException(404, { message: 'User not found' })
@@ -179,14 +187,31 @@ export default {
     )
 
     // DELETE /users/:id - Delete user
-    app.delete('/users/:id', User.validator('param', { pick: ['id'] }), async (c) => {
-      const { id } = c.req.valid('param')
-      const result = await User.delete(id)
-      if (result.deleted === 0) {
-        throw new HTTPException(404, { message: 'User not found' })
-      }
-      return c.body(null, 204)
-    })
+    app.delete(
+      '/users/:id',
+      {
+        openapi: {
+          summary: 'Delete user',
+          params: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
+          ],
+          responses: {
+            '204': { description: 'User deleted' },
+            '404': { description: 'User not found' },
+          },
+        },
+      },
+      User.validator('param', { pick: ['id'] }) as import('hono').MiddlewareHandler,
+      async (c) => {
+        // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
+        const { id } = (c.req.valid as (target: 'param') => any)('param')
+        const result = await User.delete(id)
+        if (result.deleted === 0) {
+          throw new HTTPException(404, { message: 'User not found' })
+        }
+        return c.body(null, 204)
+      },
+    )
 
     app.get('/openapi.json', (c) =>
       c.json(

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -384,7 +384,7 @@ export default {
 }
 ```
 
-Nanoka apps are Hono instances extended with `model()`, `db`, `batch()`, `openapi()`, and `generateOpenAPISpec()`. All standard Hono middleware and patterns work directly.
+Nanoka apps are Hono instances extended with `model()`, `db`, `batch()`, `openapi()`, `generateOpenAPISpec()`, and inline `{ openapi }` route metadata. All standard Hono middleware and patterns work directly.
 
 ## OpenAPI
 
@@ -401,7 +401,46 @@ These are documentation helpers, not enforcement sources.
 
 **Route-level OpenAPI**
 
-Register operation metadata with `app.openapi()`. `app.openapi()` is a separate method call (not a chain). Both `path` and `method` are required:
+Two equivalent ways to register route-level OpenAPI metadata:
+
+**Option 1: inline `{ openapi }` as the second argument (concise)**
+
+Pass `{ openapi: RouteOpenAPIMetadata }` as the second argument to `app.get/post/put/patch/delete`. `path` and `method` are inferred from the call site.
+
+Known limitation: `c.req.valid` loses its narrowed type in the handler because the overload uses a generic `H[]` rest-parameter. Cast explicitly or use Option 2 when handler type inference matters.
+
+```ts
+app.post(
+  '/users',
+  {
+    openapi: {
+      summary: 'Create a user',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+      },
+      responses: {
+        '201': {
+          description: 'User created',
+          content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+        },
+        '400': { description: 'Validation error' },
+      },
+    },
+  },
+  User.validator('json', 'create') as import('hono').MiddlewareHandler,
+  async (c) => {
+    // c.req.valid loses inferred type with inline { openapi } — cast explicitly
+    const body = (c.req.valid as (target: 'json') => any)('json')
+    const user = await User.create(body)
+    return c.json(user, 201)
+  },
+)
+```
+
+**Option 2: standalone `app.openapi()` call (full type inference preserved)**
+
+`app.openapi()` is a separate method call (not a chain). Both `path` and `method` are required. Prefer this when `c.req.valid` type inference in the handler matters:
 
 ```ts
 app.openapi({

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/index.ts
+++ b/packages/nanoka/src/index.ts
@@ -24,7 +24,8 @@ export type {
   OpenAPISchemaObject,
   OpenAPISpecOptions,
   OpenAPIUsage,
+  RouteOpenAPIMetadata,
 } from './openapi'
 export { swaggerUI } from './openapi'
-export type { Nanoka, NanokaModel } from './router'
+export type { Nanoka, NanokaModel, RouteOpenAPIOption } from './router'
 export { nanoka } from './router'

--- a/packages/nanoka/src/openapi/index.ts
+++ b/packages/nanoka/src/openapi/index.ts
@@ -12,4 +12,5 @@ export type {
   OpenAPISchemaObject,
   OpenAPISpecOptions,
   OpenAPIUsage,
+  RouteOpenAPIMetadata,
 } from './types'

--- a/packages/nanoka/src/openapi/types.ts
+++ b/packages/nanoka/src/openapi/types.ts
@@ -45,6 +45,8 @@ export interface OpenAPIRouteMetadata {
   readonly responses: Record<string, OpenAPIResponseSpec>
 }
 
+export type RouteOpenAPIMetadata = Omit<OpenAPIRouteMetadata, 'path' | 'method'>
+
 export interface OpenAPISpecOptions {
   readonly info: {
     readonly title: string

--- a/packages/nanoka/src/router/__tests__/openapi-integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/openapi-integration.test.ts
@@ -75,6 +75,98 @@ describe('app.openapi() integration', () => {
     expect(spec.paths['/b']).toBeDefined()
   })
 
+  it('inline { openapi } option registers metadata via app.post()', () => {
+    const adapter = createMockAdapter()
+    const app = nanoka(adapter)
+
+    app.post(
+      '/users',
+      {
+        openapi: {
+          summary: 'Create user',
+          responses: { '201': { description: 'Created' } },
+        },
+      },
+      async (c) => c.json({ ok: true }, 201),
+    )
+
+    const spec = app.generateOpenAPISpec({ info: { title: 'T', version: '0' } })
+    const usersPath = spec.paths['/users'] as Record<string, unknown>
+    expect(usersPath).toBeDefined()
+    const op = usersPath.post as Record<string, unknown>
+    expect(op).toBeDefined()
+    expect(op.summary).toBe('Create user')
+  })
+
+  it('inline { openapi } and standalone app.openapi() coexist in the same spec', () => {
+    const adapter = createMockAdapter()
+    const app = nanoka(adapter)
+
+    app.openapi({
+      path: '/users',
+      method: 'get',
+      summary: 'List users',
+      responses: { '200': { description: 'OK' } },
+    })
+
+    app.post(
+      '/users',
+      {
+        openapi: {
+          summary: 'Create user',
+          responses: { '201': { description: 'Created' } },
+        },
+      },
+      async (c) => c.json({ ok: true }, 201),
+    )
+
+    const spec = app.generateOpenAPISpec({ info: { title: 'T', version: '0' } })
+    const usersPath = spec.paths['/users'] as Record<string, unknown>
+    expect(usersPath.get).toBeDefined()
+    expect(usersPath.post).toBeDefined()
+    const postOp = usersPath.post as Record<string, unknown>
+    expect(postOp.summary).toBe('Create user')
+    const getOp = usersPath.get as Record<string, unknown>
+    expect(getOp.summary).toBe('List users')
+  })
+
+  it('inline { openapi } works alongside a validator middleware', async () => {
+    const adapter = createMockAdapter()
+    const app = nanoka(adapter)
+
+    const User = app.model('users', {
+      id: t.uuid().primary().readOnly(),
+      name: t.string(),
+    })
+
+    app.post(
+      '/users',
+      {
+        openapi: {
+          summary: 'Create user',
+          responses: { '201': { description: 'Created' } },
+        },
+      },
+      User.validator('json', 'create') as import('hono').MiddlewareHandler,
+      async (c) => {
+        // biome-ignore lint/suspicious/noExplicitAny: inline openapi overload uses H[] which loses validator type inference
+        const body = (c.req.valid as (target: 'json') => any)('json')
+        return c.json(body, 201)
+      },
+    )
+
+    const spec = app.generateOpenAPISpec({ info: { title: 'T', version: '0' } })
+    const usersPath = spec.paths['/users'] as Record<string, unknown>
+    expect(usersPath.post).toBeDefined()
+
+    const res = await app.request('/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice' }),
+    })
+    expect(res.status).toBe(201)
+  })
+
   it('strict mode throws when schema contains unsupported Zod types', () => {
     const adapter = createMockAdapter()
     const app = nanoka(adapter)

--- a/packages/nanoka/src/router/index.ts
+++ b/packages/nanoka/src/router/index.ts
@@ -1,2 +1,2 @@
 export { nanoka } from './nanoka'
-export type { Nanoka, NanokaModel } from './types'
+export type { Nanoka, NanokaModel, RouteOpenAPIOption } from './types'

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -1,11 +1,11 @@
 import { Hono } from 'hono'
-import type { BlankEnv, Env } from 'hono/types'
+import type { BlankEnv, Env, H } from 'hono/types'
 import type { Adapter } from '../adapter/types'
 import type { Field } from '../field/types'
 import { defineModel } from '../model/define'
 import { buildOpenAPIDocument } from '../openapi/route'
-import type { OpenAPIRouteMetadata } from '../openapi/types'
-import type { Nanoka, NanokaModel } from './types'
+import type { HttpMethod, OpenAPIRouteMetadata } from '../openapi/types'
+import type { Nanoka, NanokaModel, RouteOpenAPIOption } from './types'
 
 /**
  * Creates a Nanoka application instance with the given database adapter.
@@ -44,6 +44,29 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
   }
 
   app.generateOpenAPISpec = (options) => buildOpenAPIDocument(openapiRoutes, options)
+
+  function wrapWithOpenAPI(method: HttpMethod) {
+    // biome-ignore lint/suspicious/noExplicitAny: original Hono method is typed as HandlerInterface which needs any at call site
+    const original = (app as any)[method].bind(app)
+    // biome-ignore lint/suspicious/noExplicitAny: overload bridge — type safety is provided by the Nanoka interface overload
+    ;(app as any)[method] = (path: string, second: RouteOpenAPIOption | H, ...rest: H[]) => {
+      if (
+        second !== null &&
+        typeof second === 'object' &&
+        !Array.isArray(second) &&
+        typeof (second as RouteOpenAPIOption).openapi === 'object'
+      ) {
+        const { openapi } = second as RouteOpenAPIOption
+        openapiRoutes.push({ ...openapi, path, method })
+        return original(path, ...rest)
+      }
+      return original(path, second, ...rest)
+    }
+  }
+
+  for (const method of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+    wrapWithOpenAPI(method)
+  }
 
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field generic constraint
   app.model = function model<Fields extends Record<string, Field<any, any, any>>>(

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -1,6 +1,6 @@
 import type { Hook } from '@hono/zod-validator'
 import type { Hono, MiddlewareHandler } from 'hono'
-import type { BlankEnv, Env } from 'hono/types'
+import type { BlankEnv, Env, H, HandlerInterface } from 'hono/types'
 import type { z } from 'zod'
 import type { Adapter } from '../adapter/types'
 import type { Field } from '../field/types'
@@ -24,6 +24,7 @@ import type {
   OpenAPISchemaObject,
   OpenAPISpecOptions,
   OpenAPIUsage,
+  RouteOpenAPIMetadata,
 } from '../openapi/types'
 
 /**
@@ -165,6 +166,14 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
 }
 
 /**
+ * Inline OpenAPI metadata option accepted as the second argument to
+ * app.get/post/put/patch/delete when registering a route with OpenAPI.
+ */
+export interface RouteOpenAPIOption {
+  readonly openapi: RouteOpenAPIMetadata
+}
+
+/**
  * Nanoka application: a Hono instance extended with model registration,
  * adapter binding, and escape hatches for raw Drizzle and batch operations.
  */
@@ -206,4 +215,19 @@ export interface Nanoka<E extends Env = BlankEnv> extends Hono<E> {
    * Builds the full OpenAPI 3.1 document from all registered openapi() metadata.
    */
   generateOpenAPISpec(options: OpenAPISpecOptions): OpenAPIDocument
+
+  // Overloads that accept inline { openapi } metadata as the second argument.
+  // Known limitation: handler context `c.req.valid` loses its inferred type
+  // in this form because the rest parameters use the generic H[] signature.
+  // Use app.openapi() + separate route definition when handler type inference matters.
+  get: ((path: string, meta: RouteOpenAPIOption, ...handlers: H[]) => this) &
+    HandlerInterface<E, 'get', import('hono/types').BlankSchema, '/'>
+  post: ((path: string, meta: RouteOpenAPIOption, ...handlers: H[]) => this) &
+    HandlerInterface<E, 'post', import('hono/types').BlankSchema, '/'>
+  put: ((path: string, meta: RouteOpenAPIOption, ...handlers: H[]) => this) &
+    HandlerInterface<E, 'put', import('hono/types').BlankSchema, '/'>
+  patch: ((path: string, meta: RouteOpenAPIOption, ...handlers: H[]) => this) &
+    HandlerInterface<E, 'patch', import('hono/types').BlankSchema, '/'>
+  delete: ((path: string, meta: RouteOpenAPIOption, ...handlers: H[]) => this) &
+    HandlerInterface<E, 'delete', import('hono/types').BlankSchema, '/'>
 }


### PR DESCRIPTION
## Summary

- `app.post(path, { openapi: {...} }, ...handlers)` 形式で OpenAPI メタデータを route 定義に直接渡せる短縮 API を追加
- `examples/basic/src/index.ts` の独立した `app.openapi()` 呼び出し（約 70 行）を各 route に統合してボイラープレートを削減
- 既存の `app.openapi({ path, method, ... })` は後方互換のまま維持
- `RouteOpenAPIMetadata` / `RouteOpenAPIOption` 型を public export に追加
- Known limitation: inline `{ openapi }` 形式では `c.req.valid` の型推論が失われる（`H[]` variadic 制約）。型安全が必要な場合は `app.openapi()` + 別途 route 定義を使用

## Test plan

- [x] `pnpm -C packages/nanoka typecheck` — pass
- [x] `pnpm -C packages/nanoka test` — 31 tests pass (node), 334 tests pass (workers)
- [x] `pnpm -C examples/basic typecheck` — pass
- [x] `pnpm -C examples/basic test` — 9 tests pass
- [x] `pnpm lint` — errors 0

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)