### PR TITLE
feat: t.uuid().primary().readOnly() に暗黙 UUID 自動生成を追加 (v1.3.0)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -32,6 +32,7 @@
 - CLI scaffolder package: `create-nanoka-app`
 - Unified migration workflow: `nanoka generate --apply --db <name>` — [#41](https://github.com/nanokajs/nanoka/issues/41)
 - Inline route OpenAPI: `app.post(path, { openapi: {...} }, ...handlers)` — [#38](https://github.com/nanokajs/nanoka/issues/38)
+- `t.uuid().primary().readOnly()` 暗黙 UUID 自動生成 — [#42](https://github.com/nanokajs/nanoka/issues/42)
 
 ### AI coding support
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -243,12 +243,7 @@ const CreateUserBody = User.inputSchema('create').extend({ password: z.string().
 app.post('/users', zValidator('json', CreateUserBody), async (c) => {
   const { password, ...body } = c.req.valid('json')
   const passwordHash = await hash(password)
-  const created = await User.create({
-    ...body,
-    id: crypto.randomUUID(),
-    passwordHash,
-    createdAt: new Date(),
-  })
+  const created = await User.create({ ...body, passwordHash })
   // password / passwordHash を絶対に返さない（toResponse が serverOnly を strip）
   return c.json(User.toResponse(created))
 })

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -158,7 +158,7 @@ Routes use `User.validator('json', { omit: ['passwordHash', 'createdAt', 'id'] }
 ```typescript
 app.post('/users', User.validator('json', { omit: ['passwordHash', 'createdAt', 'id'] }), async (c) => {
   const body = c.req.valid('json')  // passwordHash, createdAt, id already filtered out
-  const created = await User.create({ ...body, id: crypto.randomUUID(), passwordHash: 'demo-...' })
+  const created = await User.create({ ...body, passwordHash: 'demo-...' })  // id and createdAt auto-generated
   return c.json(User.schema({ omit: ['passwordHash'] }).parse(created), 201)
 })
 ```

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -62,19 +62,12 @@ export default {
       async (c) => {
         // biome-ignore lint/suspicious/noExplicitAny: known limitation, see above
         const body = (c.req.valid as (target: 'json') => any)('json')
-        const id = crypto.randomUUID()
         // SECURITY: demo-only — the email is reversible, NEVER use in production.
         // Replace with a real password hash (bcrypt, argon2, scrypt) or accept a
         // pre-hashed value from the client and verify the algorithm.
         const passwordHash = `demo-${body.email}`
-        const createdAt = new Date()
 
-        // app.db 経由の行は policy 未適用（passwordHash を含む完全な DB 行）。必ず User.toResponse() を通すこと。
-        const rows = await app.db
-          .insert(User.table)
-          .values({ ...body, id, passwordHash, createdAt })
-          .returning()
-        const created = rows[0] as import('@nanokajs/core').RowType<typeof User.fields>
+        const created = await User.create({ ...body, passwordHash })
 
         return c.json(User.toResponse(created), 201)
       },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -242,9 +242,9 @@ const user = await User.findOne({ email: 'alice@example.com' })  // by where cla
 
 ```ts
 const user = await User.create({
-  id: crypto.randomUUID(),
   email: 'alice@example.com',
   name: 'Alice',
+  // id omitted — auto-generated if t.uuid().primary().readOnly()
   // passwordHash omitted if serverOnly; password accepted if writeOnly
 })
 ```
@@ -673,11 +673,7 @@ export default {
       Post.validator('json', { omit: f => [f.id, f.createdAt] }),
       async (c) => {
         const body = c.req.valid('json')
-        const post = await Post.create({
-          ...body,
-          id: crypto.randomUUID(),
-          createdAt: new Date(),
-        })
+        const post = await Post.create({ ...body, id: crypto.randomUUID(), createdAt: new Date() })
         return c.json(post, 201)
       }
     )

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -25,7 +25,7 @@ The following APIs are stable. Breaking changes require a major version bump.
 
 - **Field DSL**: `t.string()` / `t.uuid()` / `t.integer()` / `t.number()` / `t.boolean()` / `t.timestamp()` / `t.json(zodSchema?)`
 - **Field modifiers**: `.primary()` / `.unique()` / `.optional()` / `.default(fn)` / `.min(n)` / `.max(n)` / `.email()`
-- **Field policies**: `.serverOnly()` / `.writeOnly()` / `.readOnly()`
+- **Field policies**: `.serverOnly()` / `.writeOnly()` / `.readOnly()` — `t.uuid().primary().readOnly()` implicitly generates a UUID via `crypto.randomUUID()` when no `.default()` is provided
 - **Schema derivation**: `Model.schema(opts?)` / `Model.inputSchema('create' | 'update', opts?)` / `Model.outputSchema(opts?)`
 - **Validator**: `Model.validator(target, opts | preset, hook?)` — presets: `'create'`, `'update'`
 - **Response shaping**: `Model.toResponse(row)`
@@ -184,11 +184,7 @@ export default {
       Post.validator('json', { omit: ['id', 'createdAt'] }),
       async (c) => {
         const body = c.req.valid('json')
-        const created = await Post.create({
-          ...body,
-          id: crypto.randomUUID(),
-          createdAt: new Date(),
-        })
+        const created = await Post.create({ ...body, id: crypto.randomUUID() })
         return c.json(created, 201)
       }
     )

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/field/__tests__/field.test.ts
+++ b/packages/nanoka/src/field/__tests__/field.test.ts
@@ -149,6 +149,40 @@ describe('Field: runtime behavior', () => {
       // biome-ignore lint/suspicious/noExplicitAny: Testing that email method doesn't exist
       expect(typeof (field as any).email).toBe('undefined')
     })
+
+    it('t.uuid().primary().readOnly() drizzleColumn has hasDefault: true', () => {
+      const field = t.uuid().primary().readOnly()
+      const col = field.drizzleColumn('id')
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing drizzle internal config
+      expect((col as any).config?.hasDefault).toBe(true)
+    })
+
+    it('t.uuid().primary() without readOnly does not set hasDefault', () => {
+      const field = t.uuid().primary()
+      const col = field.drizzleColumn('id')
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing drizzle internal config
+      expect((col as any).config?.hasDefault).toBe(false)
+    })
+
+    it('t.uuid().readOnly() without primary does not set hasDefault', () => {
+      const field = t.uuid().readOnly()
+      const col = field.drizzleColumn('id')
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing drizzle internal config
+      expect((col as any).config?.hasDefault).toBe(false)
+    })
+
+    it('t.uuid().primary().readOnly().default() uses user default over implicit default', () => {
+      const field = t
+        .uuid()
+        .primary()
+        .readOnly()
+        .default(() => 'fixed-id')
+      const col = field.drizzleColumn('id')
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing drizzle internal config
+      expect((col as any).config?.hasDefault).toBe(true)
+      // biome-ignore lint/suspicious/noExplicitAny: Accessing drizzle internal config
+      expect((col as any).config?.defaultFn()).toBe('fixed-id')
+    })
   })
 
   describe('number field', () => {

--- a/packages/nanoka/src/field/factories.ts
+++ b/packages/nanoka/src/field/factories.ts
@@ -204,6 +204,13 @@ class UuidFieldBuilder<
     if (this.modifiers.unique) {
       col = col.unique()
     }
+    if (
+      this.modifiers.primary === true &&
+      this.modifiers.policy === 'readOnly' &&
+      !this.modifiers.hasDefault
+    ) {
+      col = col.$defaultFn(() => crypto.randomUUID())
+    }
     if (this.modifiers.hasDefault) {
       const defaultValue = this.modifiers.defaultValue
       if (typeof defaultValue === 'function') {

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -12,6 +12,55 @@ declare module 'cloudflare:test' {
   }
 }
 
+describe('readOnly primary UUID auto-generation', () => {
+  const AutoModel = defineModel('auto_users', {
+    id: t.uuid().primary().readOnly(),
+    name: t.string(),
+    createdAt: t
+      .timestamp()
+      .readOnly()
+      .default(() => new Date()),
+  })
+
+  beforeEach(async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS auto_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE auto_users (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          createdAt INTEGER NOT NULL
+        )
+      `,
+    )
+  })
+
+  it('create fills id (UUID) and createdAt (Date) automatically', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const created = await AutoModel.create(adapter, { name: 'Alice' })
+
+    expect(typeof created.id).toBe('string')
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    expect(created.createdAt instanceof Date).toBe(true)
+    expect(created.name).toBe('Alice')
+  })
+
+  it('two consecutive creates produce unique UUIDs', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const first = await AutoModel.create(adapter, { name: 'Bob' })
+    const second = await AutoModel.create(adapter, { name: 'Carol' })
+
+    expect(first.id).not.toBe(second.id)
+  })
+})
+
 describe('CRUD operations: vitest-pool-workers D1 integration', () => {
   const User = defineModel('users', {
     id: t.uuid().primary(),


### PR DESCRIPTION
## Summary

- `t.uuid().primary().readOnly()` フィールドに暗黙の `$defaultFn(() => crypto.randomUUID())` を追加し、POST ハンドラから `id = crypto.randomUUID()` の手書きを排除
- `t.timestamp().readOnly().default(() => new Date())` の自動補完が既存コードで機能することを統合テストで固定
- `examples/basic` の POST /users ハンドラを `User.create({ ...body, passwordHash })` に簡素化

## Changes

- `factories.ts` — `UuidFieldBuilder.drizzleColumn()` に `primary && readOnly && !hasDefault` の暗黙 `$defaultFn` を追加
- `field.test.ts` — 境界テスト 4 件追加（発火条件・非発火条件・ユーザー `.default()` 優先）
- `crud.integration.test.ts` — `id`/`createdAt` 自動補完の統合テスト 2 件追加
- `examples/basic/src/index.ts`、各ドキュメント — コード例を簡素化した形に同期
- version `1.2.0` → `1.3.0`

## Test plan

- [x] `pnpm -C packages/nanoka test:workers` — 340 tests passed
- [x] `pnpm -C packages/nanoka test:node` — 31 tests passed
- [x] `pnpm -C packages/nanoka typecheck` — pass
- [x] `pnpm lint` — 0 errors

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)