### PR TITLE
feat: findMany で Drizzle SQL 式を where に渡せるオーバーロードと toResponseMany を追加 (v1.5.0)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -34,6 +34,8 @@
 - Inline route OpenAPI: `app.post(path, { openapi: {...} }, ...handlers)` — [#38](https://github.com/nanokajs/nanoka/issues/38)
 - `t.uuid().primary().readOnly()` 暗黙 UUID 自動生成 — [#42](https://github.com/nanokajs/nanoka/issues/42)
 - `create-nanoka-app` テンプレートを `wrangler.jsonc` 形式に変換、`.gitignore` 生成を npm publish 対応 — [#46](https://github.com/nanokajs/nanoka/issues/46)
+- `findMany` の `where` に Drizzle SQL 式を渡せるオーバーロード — [#39](https://github.com/nanokajs/nanoka/issues/39)
+- `Model.toResponseMany(rows)` ヘルパ — [#39](https://github.com/nanokajs/nanoka/issues/39)
 
 ### AI coding support
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -184,7 +184,7 @@ app.post(
 
 If no hook is provided, `@hono/zod-validator` returns validation issues in the response (not hardened for production).
 
-### 4.6 Response shaping: `toResponse()` and arrays
+### 4.6 Response shaping: `toResponse()`, `toResponseMany()`, and arrays
 
 Single row:
 ```ts
@@ -195,10 +195,10 @@ return c.json(User.toResponse(user))
 Array of rows:
 ```ts
 const users = await User.findMany({ limit: 10 })
-return c.json(z.array(User.outputSchema()).parse(users))
+return c.json(User.toResponseMany(users))
 ```
 
-`toResponse()` is a helper equivalent to `outputSchema().parse(row)`.
+`toResponse()` is a helper equivalent to `outputSchema().parse(row)`. `toResponseMany(rows)` applies the same field policy to an array — prefer it over `rows.map(r => User.toResponse(r))` for efficiency.
 
 ### 4.7 Field accessor (typo-safe field references)
 
@@ -222,14 +222,23 @@ The `f` object is `as const`, not a Proxy. No runtime magic.
 **`findMany(options)`** — query with pagination (limit is required)
 
 ```ts
+import { like, or, eq } from 'drizzle-orm'
+
 const users = await User.findMany({ limit: 20 })
 const page2 = await User.findMany({ limit: 20, offset: 20 })
 const sorted = await User.findMany({ limit: 20, orderBy: 'email' })
+
+// Equality AND (plain object)
+const admins = await User.findMany({ limit: 20, where: { role: 'admin' } })
+
+// Drizzle SQL expression (LIKE, OR, ranges, etc.)
+const matched = await User.findMany({ limit: 20, where: like(User.table.email, '%@example.com') })
+const either = await User.findMany({ limit: 20, where: or(eq(User.table.role, 'admin'), eq(User.table.role, 'mod')) })
 ```
 
 Calling `findMany()` without `limit` is a **type error** — the parameter is required. This prevents accidental unbounded queries.
 
-Pagination shape: `{ limit, offset?, orderBy? }`
+Pagination shape: `{ limit, offset?, orderBy?, where? }`. The `where` field accepts either an equality object or any Drizzle `SQL` expression. Never pass user input to `sql.raw()` — use parametrized Drizzle operators instead.
 
 **`findOne(idOrWhere)`** — fetch single row
 
@@ -325,7 +334,17 @@ const result = await app.db
 
 `User.table` is the underlying Drizzle table. Combine with `eq()`, `lt()`, `gt()`, `and()`, `or()`, `inArray()`, `like()` from `drizzle-orm` for complex conditions. SQL injection is prevented by Drizzle's parametrized bindings.
 
-**Important**: `app.db` queries bypass field policies. Data returned from escape hatch must be manually shaped (e.g., with `outputSchema().parse()`).
+**Important**: `app.db` queries bypass field policies. Always apply `toResponseMany(rows)` (or `toResponse(row)`) to the results — skipping it leaks `serverOnly` fields like `passwordHash`.
+
+```ts
+const rows = await app.db
+  .select()
+  .from(User.table)
+  .innerJoin(Post.table, eq(User.table.id, Post.table.userId))
+  .limit(20)
+
+return c.json(User.toResponseMany(rows))
+```
 
 ### 5.3 Batch: D1 batch API directly
 
@@ -576,12 +595,12 @@ return c.json(User.toResponse(user))
 
 ```ts
 // ❌ Escape hatch bypasses field policies
-const user = await app.db.select().from(User.table).where(eq(...))
-return c.json(user) // leaks serverOnly fields
+const users = await app.db.select().from(User.table).limit(20)
+return c.json(users) // leaks serverOnly fields
 
-// ✅ Apply outputSchema
-const user = await app.db.select().from(User.table).where(eq(...))
-return c.json(outputSchema().parse(user))
+// ✅ Use toResponseMany (or toResponse for a single row)
+const users = await app.db.select().from(User.table).limit(20)
+return c.json(User.toResponseMany(users))
 ```
 
 **Do not create custom transaction abstractions**

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -28,9 +28,9 @@ The following APIs are stable. Breaking changes require a major version bump.
 - **Field policies**: `.serverOnly()` / `.writeOnly()` / `.readOnly()` — `t.uuid().primary().readOnly()` implicitly generates a UUID via `crypto.randomUUID()` when no `.default()` is provided
 - **Schema derivation**: `Model.schema(opts?)` / `Model.inputSchema('create' | 'update', opts?)` / `Model.outputSchema(opts?)`
 - **Validator**: `Model.validator(target, opts | preset, hook?)` — presets: `'create'`, `'update'`
-- **Response shaping**: `Model.toResponse(row)`
+- **Response shaping**: `Model.toResponse(row)` / `Model.toResponseMany(rows)`
 - **Field accessor** (typo-safe): `Model.schema({ pick: f => [f.fieldName] })`
-- **CRUD**: `Model.findMany({ limit, offset?, orderBy? })` / `Model.findOne` / `Model.create` / `Model.update` / `Model.delete`
+- **CRUD**: `Model.findMany({ limit, offset?, orderBy?, where? })` / `Model.findOne` / `Model.create` / `Model.update` / `Model.delete`
 - **Escape hatch**: `app.db` (raw Drizzle) / `app.batch(...)` (D1 batch)
 - **OpenAPI seed**: `Model.toOpenAPIComponent()` / `Model.toOpenAPISchema(usage)`
 - **Router**: `nanoka<E extends Env = BlankEnv>(adapter)`
@@ -309,7 +309,30 @@ const users = await User.findMany({ limit: 20, offset: 10 })
 const users = await User.findMany({ limit: 20, orderBy: 'id' })
 ```
 
-This prevents accidental unbounded queries. Pagination shape: `{ limit, offset?, orderBy? }`.
+This prevents accidental unbounded queries. Pagination shape: `{ limit, offset?, orderBy?, where? }`.
+
+The optional `where` field accepts either an equality object or a Drizzle SQL expression:
+
+```ts
+import { eq, like, or } from 'drizzle-orm'
+
+// Equality AND (plain object form)
+const admins = await User.findMany(adapter, { limit: 20, where: { role: 'admin' } })
+
+// LIKE pattern (Drizzle SQL expression)
+const exampleUsers = await User.findMany(adapter, {
+  limit: 20,
+  where: like(User.table.email, '%@example.com'),
+})
+
+// OR condition
+const specific = await User.findMany(adapter, {
+  limit: 20,
+  where: or(eq(User.table.email, 'alice@example.com'), eq(User.table.email, 'bob@example.com')),
+})
+```
+
+When passing a Drizzle SQL expression, SQL injection prevention follows Drizzle's parametrized binding rules — ensure all user-supplied values are passed as Drizzle operands (e.g., `like(col, value)`) rather than interpolated into raw strings. Never pass user input to `sql.raw()`, which skips parametrization entirely.
 
 ## Escape hatch: raw Drizzle and D1 batch
 
@@ -336,6 +359,26 @@ const result = await app.db
 For relations and N+1 prevention, use `app.db` with Drizzle's `innerJoin` / `leftJoin` directly — this is the recommended long-term approach.
 
 `User.table` is the underlying Drizzle table. Combine with `eq()`, `lt()`, `and()`, `or()` from `drizzle-orm` for complex conditions. SQL injection is prevented by Drizzle's parametrized bindings.
+
+### `toResponseMany` — safe response shaping for `app.db` results
+
+When you query via `app.db` (escape hatch) and get back raw DB rows, use `toResponseMany` to apply field policy (dropping `serverOnly`, `writeOnly` fields) across all rows at once:
+
+```ts
+import { like } from 'drizzle-orm'
+
+app.get('/users/search', async (c) => {
+  const rows = await app.db
+    .select()
+    .from(User.table)
+    .where(like(User.table.email, '%@example.com'))
+    .limit(20)
+
+  return c.json(User.toResponseMany(rows))
+})
+```
+
+`toResponseMany` builds the `outputSchema` once and maps `parse` over all rows—equivalent to `rows.map(row => User.toResponse(row))` but without rebuilding the schema per element.
 
 ### `app.batch()` — D1 batch API directly
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -1,5 +1,5 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import { sql } from 'drizzle-orm'
+import { eq, like, or, sql } from 'drizzle-orm'
 import { HTTPException } from 'hono/http-exception'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { d1Adapter } from '../../adapter/d1'
@@ -300,5 +300,138 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
         User.findMany(adapter, { limit: 20, orderBy: 'toString' as any } as any),
       ).rejects.toThrow(HTTPException)
     })
+  })
+})
+
+describe('findMany SQL where + toResponseMany', () => {
+  const WhereUser = defineModel('where_users', {
+    id: t.uuid().primary(),
+    name: t.string(),
+    email: t.string().email(),
+  })
+
+  const SecureUser = defineModel('secure_users', {
+    id: t.uuid().primary(),
+    name: t.string(),
+    email: t.string().email(),
+    passwordHash: t.string().serverOnly(),
+  })
+
+  beforeEach(async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS where_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE where_users (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL
+        )
+      `,
+    )
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS secure_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE secure_users (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL,
+          passwordHash TEXT NOT NULL
+        )
+      `,
+    )
+  })
+
+  it('where: { email } equality AND still works (regression)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await WhereUser.create(adapter, { id: 'wu-1', name: 'Alice', email: 'alice@example.com' })
+    await WhereUser.create(adapter, { id: 'wu-2', name: 'Bob', email: 'bob@example.com' })
+
+    const rows = await WhereUser.findMany(adapter, {
+      limit: 20,
+      where: { email: 'alice@example.com' },
+    })
+
+    expect(rows.length).toBe(1)
+    expect(rows[0]!.name).toBe('Alice')
+  })
+
+  it('where: like() fetches multiple matching rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await WhereUser.create(adapter, { id: 'wu-3', name: 'Charlie', email: 'charlie@example.com' })
+    await WhereUser.create(adapter, { id: 'wu-4', name: 'Diana', email: 'diana@example.com' })
+    await WhereUser.create(adapter, { id: 'wu-5', name: 'External', email: 'external@other.org' })
+
+    const rows = await WhereUser.findMany(adapter, {
+      limit: 20,
+      where: like(WhereUser.table.email, '%@example.com'),
+    })
+
+    expect(rows.length).toBe(2)
+    const emails = rows.map((r) => r.email).sort()
+    expect(emails).toEqual(['charlie@example.com', 'diana@example.com'])
+  })
+
+  it('where: or(eq(), eq()) performs OR search', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await WhereUser.create(adapter, { id: 'wu-6', name: 'Eve', email: 'eve@example.com' })
+    await WhereUser.create(adapter, { id: 'wu-7', name: 'Frank', email: 'frank@example.com' })
+    await WhereUser.create(adapter, { id: 'wu-8', name: 'Grace', email: 'grace@example.com' })
+
+    const rows = await WhereUser.findMany(adapter, {
+      limit: 20,
+      where: or(
+        eq(WhereUser.table.email, 'eve@example.com'),
+        eq(WhereUser.table.email, 'grace@example.com'),
+      ),
+    })
+
+    expect(rows.length).toBe(2)
+    const names = rows.map((r) => r.name).sort()
+    expect(names).toEqual(['Eve', 'Grace'])
+  })
+
+  it('toResponseMany removes serverOnly fields', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    // Insert directly via escape hatch because serverOnly fields are excluded from CreateInput
+    await adapter.drizzle
+      .insert(SecureUser.table)
+      // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
+      .values([
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          name: 'Heidi',
+          email: 'heidi@example.com',
+          passwordHash: 'secret9',
+        } as any,
+        {
+          id: '22222222-2222-2222-2222-222222222222',
+          name: 'Ivan',
+          email: 'ivan@example.com',
+          passwordHash: 'secret10',
+        } as any,
+      ])
+      .run()
+
+    const rows = await SecureUser.findMany(adapter, { limit: 20 })
+    const responses = SecureUser.toResponseMany(rows)
+
+    expect(responses.length).toBe(2)
+    for (const resp of responses) {
+      expect(resp).not.toHaveProperty('passwordHash')
+      expect(resp).toHaveProperty('name')
+      expect(resp).toHaveProperty('email')
+    }
   })
 })

--- a/packages/nanoka/src/model/__tests__/crud.types.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.types.test.ts
@@ -1,7 +1,8 @@
+import { like } from 'drizzle-orm'
 import { describe, it } from 'vitest'
 import { t } from '../../field'
 import { defineModel } from '../define'
-import type { CreateInput, FindManyOptions } from '../types'
+import type { CreateInput, FindManyOptions, RowType } from '../types'
 
 describe('CRUD methods: type checking', () => {
   const User = defineModel('users', {
@@ -65,6 +66,27 @@ describe('CRUD methods: type checking', () => {
         limit: 20,
         orderBy: ['name', { column: 'email', direction: 'desc' }],
       }
+      void opts
+    })
+
+    it('allows findMany with where as equality object (regression)', () => {
+      const opts: FindManyOptions<typeof User.fields> = {
+        limit: 20,
+        where: { email: 'alice@example.com' },
+      }
+      void opts
+    })
+
+    it('allows findMany with where as Drizzle SQL expression', () => {
+      const opts: FindManyOptions<typeof User.fields> = {
+        limit: 20,
+        where: like(User.table.email, '%x%'),
+      }
+      void opts
+    })
+
+    it('allows findMany with where omitted', () => {
+      const opts: FindManyOptions<typeof User.fields> = { limit: 20 }
       void opts
     })
   })
@@ -175,6 +197,23 @@ describe('CRUD methods: type checking', () => {
         email: 'alice@example.com',
       }
       void _valid
+    })
+  })
+
+  describe('toResponseMany type constraints', () => {
+    it('accepts readonly array of RowType and returns unknown[]', () => {
+      const row: RowType<typeof User.fields> = {
+        id: '00000000-0000-0000-0000-000000000000',
+        name: 'Alice',
+        email: 'alice@example.com',
+      }
+      const result: unknown[] = User.toResponseMany([row])
+      void result
+    })
+
+    it('accepts empty array', () => {
+      const result: unknown[] = User.toResponseMany([])
+      void result
     })
   })
 

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq } from 'drizzle-orm'
+import { and, asc, desc, eq, SQL } from 'drizzle-orm'
 import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import { HTTPException } from 'hono/http-exception'
 import type { Adapter } from '../adapter/types'
@@ -108,7 +108,7 @@ function buildWhereClause(
 }
 
 /**
- * Fetches multiple rows with limit, offset, and optional ordering.
+ * Fetches multiple rows with limit, offset, optional ordering, and optional where clause.
  * @internal
  */
 export async function findManyImpl<
@@ -117,11 +117,12 @@ export async function findManyImpl<
 >(
   adapter: Adapter,
   table: SQLiteTableWithColumns<any>,
-  _fields: Fields,
+  fields: Fields,
   options: {
     limit: unknown
     offset?: unknown
     orderBy?: OrderBy<Fields>
+    where?: Where<Fields> | SQL
   },
 ): Promise<RowType<Fields>[]> {
   const limit = guardLimit(options.limit)
@@ -129,6 +130,22 @@ export async function findManyImpl<
 
   // biome-ignore lint/suspicious/noExplicitAny: drizzle query builder type narrowing
   let query: any = adapter.drizzle.select().from(table).limit(limit).offset(offset)
+
+  // Apply where clause
+  if (options.where !== undefined) {
+    if (options.where instanceof SQL) {
+      query = query.where(options.where)
+    } else {
+      const whereClause = buildWhereClause(
+        table,
+        fields,
+        options.where as Where<Record<string, any>>,
+      )
+      if (whereClause !== null) {
+        query = query.where(whereClause)
+      }
+    }
+  }
 
   // Apply ordering
   if (options.orderBy !== undefined) {

--- a/packages/nanoka/src/model/define.ts
+++ b/packages/nanoka/src/model/define.ts
@@ -101,6 +101,11 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
       return this.outputSchema().parse(row)
     },
 
+    toResponseMany(rows: readonly RowType<Fields>[]): unknown[] {
+      const schema = this.outputSchema()
+      return rows.map((row) => schema.parse(row))
+    },
+
     toOpenAPIComponent() {
       return toOpenAPIComponent(fields)
     },

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -1,4 +1,5 @@
 import type { Hook } from '@hono/zod-validator'
+import type { SQL } from 'drizzle-orm'
 import type { AnySQLiteColumn, SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import type { Env, MiddlewareHandler, ValidationTargets } from 'hono'
 import type { z } from 'zod'
@@ -11,6 +12,7 @@ import type { OpenAPIModelComponent, OpenAPISchemaObject, OpenAPIUsage } from '.
  * `limit` is required (no default).
  * `offset` defaults to 0 if omitted.
  * `orderBy` is optional for column ordering.
+ * `where` accepts either an equality object or a Drizzle SQL expression.
  */
 export interface FindManyOptions<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
@@ -19,6 +21,7 @@ export interface FindManyOptions<
   readonly limit: number
   readonly offset?: number
   readonly orderBy?: OrderBy<Fields>
+  readonly where?: Where<Fields> | SQL
 }
 
 /**
@@ -582,6 +585,17 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    * Equivalent to `User.outputSchema().parse(row)`.
    */
   toResponse(row: RowType<Fields>): unknown
+
+  /**
+   * Parses an array of DB rows through outputSchema and returns safe response objects.
+   * The outputSchema is built once and reused for all rows.
+   * Equivalent to mapping `toResponse` over the array but more efficient.
+   *
+   * @example
+   * const rows = await app.db.select().from(User.table).where(...)
+   * return c.json(User.toResponseMany(rows))
+   */
+  toResponseMany(rows: readonly RowType<Fields>[]): unknown[]
 
   toOpenAPIComponent(): OpenAPIModelComponent
 

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -107,6 +107,8 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
 
       toResponse: (row) => inner.toResponse(row),
 
+      toResponseMany: (rows) => inner.toResponseMany(rows),
+
       toOpenAPIComponent: () => inner.toOpenAPIComponent(),
 
       toOpenAPISchema: (usage) => inner.toOpenAPISchema(usage),

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -128,6 +128,8 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
    */
   toResponse(row: RowType<Fields>): unknown
 
+  toResponseMany(rows: readonly RowType<Fields>[]): unknown[]
+
   toOpenAPIComponent(): OpenAPIModelComponent
 
   toOpenAPISchema(usage: OpenAPIUsage): OpenAPISchemaObject


### PR DESCRIPTION
## Summary

- `findMany` の `where` に Drizzle の `SQL` 式を渡せるオーバーロードを追加（`like`, `or`, `and`, `inArray` 等をそのまま渡せる）
- `Model.toResponseMany(rows)` ヘルパを追加（`app.db` フォールバック結果への field policy 一括適用）
- `NanokaModel` インターフェース（`router/types.ts`）と委譲（`nanoka.ts`）にも `toResponseMany` を追加
- README / `llms-full.txt` に新パターン例・`sql.raw()` 警告・escape hatch 安全パターンを追記

## 背景

複雑なクエリ（LIKE / OR / JOIN）で `app.db` にフォールバックした際、`toResponse()` の呼び忘れが `serverOnly` フィールドの漏洩リスクになっていた。

- `findMany({ where: like(User.table.email, '%@example.com') })` — Drizzle 演算子を再発明せず透過させる
- `User.toResponseMany(rows)` — escape hatch 結果に field policy を安全に適用

「Drizzle replacement DSL 再発明なし」「`limit` 必須維持」の設計原則を守りつつ、Drizzle との統合を強化。

## Test plan

- [x] `findMany` の等価 AND（既存形）regression テスト
- [x] `findMany({ where: like(...) })` の D1 統合テスト
- [x] `findMany({ where: or(...) })` の D1 統合テスト
- [x] `toResponseMany` が `serverOnly` フィールドを除去することを D1 統合テストで確認
- [x] 型テスト（SQL 式 / 等価 object / 不正キー拒否）
- [x] `pnpm -C packages/nanoka test`（349 tests pass）
- [x] `pnpm -C packages/nanoka typecheck`（pass）
- [x] `pnpm lint`（エラー 0）

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)