### PR TITLE
feat: findAll を追加し MAX_LIMIT を廃止する (v1.6.0)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -36,6 +36,7 @@
 - `create-nanoka-app` テンプレートを `wrangler.jsonc` 形式に変換、`.gitignore` 生成を npm publish 対応 — [#46](https://github.com/nanokajs/nanoka/issues/46)
 - `findMany` の `where` に Drizzle SQL 式を渡せるオーバーロード — [#39](https://github.com/nanokajs/nanoka/issues/39)
 - `Model.toResponseMany(rows)` ヘルパ — [#39](https://github.com/nanokajs/nanoka/issues/39)
+- `Model.findAll(adapter, options?)` — LIMIT なし全件取得。`findMany` の `MAX_LIMIT = 100` ランタイムキャップを廃止 — [#49](https://github.com/nanokajs/nanoka/issues/49)
 
 ### AI coding support
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -219,26 +219,38 @@ The `f` object is `as const`, not a Proxy. No runtime magic.
 
 ### 4.8 CRUD
 
-**`findMany(options)`** — query with pagination (limit is required)
+**`findMany(adapter, options)`** — query with pagination (limit is required)
 
 ```ts
 import { like, or, eq } from 'drizzle-orm'
 
-const users = await User.findMany({ limit: 20 })
-const page2 = await User.findMany({ limit: 20, offset: 20 })
-const sorted = await User.findMany({ limit: 20, orderBy: 'email' })
+const users = await User.findMany(adapter, { limit: 20 })
+const page2 = await User.findMany(adapter, { limit: 20, offset: 20 })
+const sorted = await User.findMany(adapter, { limit: 20, orderBy: 'email' })
 
 // Equality AND (plain object)
-const admins = await User.findMany({ limit: 20, where: { role: 'admin' } })
+const admins = await User.findMany(adapter, { limit: 20, where: { role: 'admin' } })
 
 // Drizzle SQL expression (LIKE, OR, ranges, etc.)
-const matched = await User.findMany({ limit: 20, where: like(User.table.email, '%@example.com') })
-const either = await User.findMany({ limit: 20, where: or(eq(User.table.role, 'admin'), eq(User.table.role, 'mod')) })
+const matched = await User.findMany(adapter, { limit: 20, where: like(User.table.email, '%@example.com') })
+const either = await User.findMany(adapter, { limit: 20, where: or(eq(User.table.role, 'admin'), eq(User.table.role, 'mod')) })
 ```
 
 Calling `findMany()` without `limit` is a **type error** — the parameter is required. This prevents accidental unbounded queries.
 
 Pagination shape: `{ limit, offset?, orderBy?, where? }`. The `where` field accepts either an equality object or any Drizzle `SQL` expression. Never pass user input to `sql.raw()` — use parametrized Drizzle operators instead.
+
+**`findAll(options?)`** — fetch all rows without LIMIT
+
+```ts
+// All rows (no limit)
+const users = await User.findAll(adapter)
+
+// With filtering and ordering
+const admins = await User.findAll(adapter, { orderBy: 'name', where: { role: 'admin' } })
+```
+
+Options: `{ offset?, orderBy?, where? }`. No `limit` parameter. Issues no LIMIT clause to the database. For batch processing / admin tooling. Apply an app-level size guard when used in request handlers.
 
 **`findOne(idOrWhere)`** — fetch single row
 
@@ -574,10 +586,29 @@ return c.json(User.toResponse(user))
 
 ```ts
 // ❌ Type error
-const users = await User.findMany()
+const users = await User.findMany(adapter)
 
 // ✅ Correct
-const users = await User.findMany({ limit: 20 })
+const users = await User.findMany(adapter, { limit: 20 })
+```
+
+**Do not use `findAll()` in request handlers without an app-level size guard**
+
+```ts
+// ❌ Unbounded query in a request handler — may return millions of rows
+app.get('/users', async (c) => {
+  const users = await User.findAll(adapter)
+  return c.json(users)
+})
+
+// ✅ Use findMany with limit for request handlers
+app.get('/users', async (c) => {
+  const users = await User.findMany(adapter, { limit: 100 })
+  return c.json(users)
+})
+
+// ✅ findAll is appropriate for batch jobs / admin scripts
+const allUsers = await User.findAll(adapter)
 ```
 
 **Do not pass DB rows directly to responses**

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to `@nanokajs/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] — 2026-05-05
+
+### Added
+
+- `Model.findAll(adapter, options?)` — fetches all rows without a LIMIT clause. Options support `offset`, `orderBy`, and `where` (plain object or Drizzle SQL expression). For batch processing / admin tooling; apply an app-level size guard when used in request handlers.
+- `FindAllOptions<Fields>` type exported from `@nanokajs/core`.
+
+### Changed
+
+- `findMany` no longer enforces a `MAX_LIMIT = 100` runtime cap. Calling `findMany(adapter, { limit: 1000 })` now executes normally. The type-level requirement that `limit` is a required parameter is unchanged.
+
+## [1.5.0] — 2026-05-04
+
+### Added
+
+- `findMany` の `where` に Drizzle SQL 式（`like`、`or`、`gt` 等）を渡せるオーバーロードを追加。plain object（等価 AND）と `SQL` 式の両方を受け付ける。
+- `Model.toResponseMany(rows)` — row 配列に field policy を一括適用するヘルパ。
+
+## [1.4.0] — 2026-05-04
+
+### Changed
+
+- `create-nanoka-app` のテンプレートを `wrangler.toml` から `wrangler.jsonc` 形式に変換。
+- `.gitignore` の生成を npm publish 対応に修正（`node_modules` 等が正しく除外される）。
+
+## [1.3.0] — 2026-05-04
+
+### Added
+
+- `t.uuid().primary().readOnly()` に暗黙 UUID 自動生成を追加。`create` 呼び出し時に id を省略すると自動的に `crypto.randomUUID()` が設定される。
+
+## [1.2.0] — 2026-05-04
+
+### Added
+
+- route 定義に inline `{ openapi: {...} }` を渡せる短縮 API を追加。`app.post(path, { openapi: metadata }, ...handlers)` の形式で OpenAPI メタデータをルートと同じ場所に記述できる。
+
 ## [1.1.0] — 2026-05-04
 
 ### Added

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -30,7 +30,7 @@ The following APIs are stable. Breaking changes require a major version bump.
 - **Validator**: `Model.validator(target, opts | preset, hook?)` — presets: `'create'`, `'update'`
 - **Response shaping**: `Model.toResponse(row)` / `Model.toResponseMany(rows)`
 - **Field accessor** (typo-safe): `Model.schema({ pick: f => [f.fieldName] })`
-- **CRUD**: `Model.findMany({ limit, offset?, orderBy?, where? })` / `Model.findOne` / `Model.create` / `Model.update` / `Model.delete`
+- **CRUD**: `Model.findMany({ limit, offset?, orderBy?, where? })` / `Model.findAll(options?)` / `Model.findOne` / `Model.create` / `Model.update` / `Model.delete`
 - **Escape hatch**: `app.db` (raw Drizzle) / `app.batch(...)` (D1 batch)
 - **OpenAPI seed**: `Model.toOpenAPIComponent()` / `Model.toOpenAPISchema(usage)`
 - **Router**: `nanoka<E extends Env = BlankEnv>(adapter)`
@@ -333,6 +333,25 @@ const specific = await User.findMany(adapter, {
 ```
 
 When passing a Drizzle SQL expression, SQL injection prevention follows Drizzle's parametrized binding rules — ensure all user-supplied values are passed as Drizzle operands (e.g., `like(col, value)`) rather than interpolated into raw strings. Never pass user input to `sql.raw()`, which skips parametrization entirely.
+
+### `findAll` — unbounded fetch (no LIMIT)
+
+`findAll` issues no LIMIT clause and returns every row. Use it for batch processing, admin tooling, or export pipelines where you intentionally want all records.
+
+```ts
+// Fetch all users (no limit)
+const users = await User.findAll(adapter)
+
+// With filtering and ordering
+const admins = await User.findAll(adapter, { orderBy: 'name', where: { role: 'admin' } })
+
+// Apply toResponseMany to strip serverOnly fields
+return c.json(User.toResponseMany(users))
+```
+
+`findAll` accepts `offset`, `orderBy`, and `where` — the same semantics as `findMany`. It does **not** accept `limit`.
+
+**Warning:** `findAll` issues no LIMIT to the database. For request handlers, enforce an app-level size guard or use `findMany` with an explicit `limit` instead.
 
 ## Escape hatch: raw Drizzle and D1 batch
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/index.ts
+++ b/packages/nanoka/src/index.ts
@@ -4,6 +4,7 @@ export type { Field, FieldModifiers, FieldPolicy, InferFieldType } from './field
 export { t } from './field'
 export type {
   CreateInput,
+  FindAllOptions,
   FindManyOptions,
   IdOrWhere,
   Model,

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -256,11 +256,14 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       await expect(User.findMany(adapter, { limit: NaN } as any)).rejects.toThrow(HTTPException)
     })
 
-    it('12. reject limit > MAX_LIMIT (100)', async () => {
+    it('12. limit: 1000 does not throw (MAX_LIMIT cap removed)', async () => {
       const { env } = await import('cloudflare:test')
       const adapter = d1Adapter(env.DB)
 
-      await expect(User.findMany(adapter, { limit: 1000 })).rejects.toThrow(HTTPException)
+      await User.create(adapter, { id: 'uuid-12', name: 'Test', email: 'test12@example.com' })
+
+      const rows = await User.findMany(adapter, { limit: 1000 })
+      expect(rows.length).toBeGreaterThanOrEqual(1)
     })
 
     it('13. reject delete with empty where clause', async () => {
@@ -433,5 +436,134 @@ describe('findMany SQL where + toResponseMany', () => {
       expect(resp).toHaveProperty('name')
       expect(resp).toHaveProperty('email')
     }
+  })
+})
+
+describe('findAll', () => {
+  const AllUser = defineModel('all_users', {
+    id: t.uuid().primary(),
+    name: t.string(),
+    email: t.string().email(),
+  })
+
+  beforeEach(async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS all_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE all_users (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL
+        )
+      `,
+    )
+
+    await AllUser.create(adapter, { id: 'all-1', name: 'Alice', email: 'alice@example.com' })
+    await AllUser.create(adapter, { id: 'all-2', name: 'Bob', email: 'bob@example.com' })
+    await AllUser.create(adapter, { id: 'all-3', name: 'Charlie', email: 'charlie@example.com' })
+  })
+
+  it('returns all rows without arguments', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter)
+    expect(rows.length).toBe(3)
+  })
+
+  it('returns all rows with empty options object', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, {})
+    expect(rows.length).toBe(3)
+  })
+
+  it('offset reduces returned rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, { offset: 1, orderBy: 'id' })
+    expect(rows.length).toBe(2)
+    expect(rows[0]!.id).toBe('all-2')
+    expect(rows[1]!.id).toBe('all-3')
+  })
+
+  it('orderBy asc sorts correctly', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, { orderBy: 'name' })
+    expect(rows.map((r) => r.name)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+
+  it('orderBy desc sorts correctly', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, { orderBy: { column: 'name', direction: 'desc' } })
+    expect(rows.map((r) => r.name)).toEqual(['Charlie', 'Bob', 'Alice'])
+  })
+
+  it('orderBy as array sorts by multiple columns', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, {
+      orderBy: ['name', { column: 'id', direction: 'asc' }],
+    })
+    expect(rows.map((r) => r.name)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+
+  it('where plain object filters rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, { where: { email: 'alice@example.com' } })
+    expect(rows.length).toBe(1)
+    expect(rows[0]!.name).toBe('Alice')
+  })
+
+  it('where Drizzle SQL expression (like) filters rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await AllUser.findAll(adapter, {
+      where: like(AllUser.table.email, '%@example.com'),
+    })
+    expect(rows.length).toBe(3)
+  })
+
+  it('rejects invalid orderBy column name (identifier injection guard)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentional invalid orderBy for guard test
+      AllUser.findAll(adapter, { orderBy: 'evil; drop' as any }),
+    ).rejects.toThrow(HTTPException)
+  })
+
+  it('rejects negative offset', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentional invalid offset for guard test
+      AllUser.findAll(adapter, { offset: -1 as any }),
+    ).rejects.toThrow(HTTPException)
+  })
+
+  it('rejects non-integer offset', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentional invalid offset for guard test
+      AllUser.findAll(adapter, { offset: 1.5 as any }),
+    ).rejects.toThrow(HTTPException)
   })
 })

--- a/packages/nanoka/src/model/__tests__/crud.types.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.types.test.ts
@@ -1,8 +1,9 @@
 import { like } from 'drizzle-orm'
 import { describe, it } from 'vitest'
+import type { Adapter } from '../../adapter/types'
 import { t } from '../../field'
 import { defineModel } from '../define'
-import type { CreateInput, FindManyOptions, RowType } from '../types'
+import type { CreateInput, FindAllOptions, FindManyOptions, RowType } from '../types'
 
 describe('CRUD methods: type checking', () => {
   const User = defineModel('users', {
@@ -88,6 +89,52 @@ describe('CRUD methods: type checking', () => {
     it('allows findMany with where omitted', () => {
       const opts: FindManyOptions<typeof User.fields> = { limit: 20 }
       void opts
+    })
+  })
+
+  describe('findAll type constraints', () => {
+    it('allows findAll with no options (options omitted)', () => {
+      // biome-ignore lint/suspicious/noExplicitAny: intentional adapter stub
+      User.findAll({} as any)
+    })
+
+    it('allows findAll with offset', () => {
+      const opts: FindAllOptions<typeof User.fields> = { offset: 10 }
+      void opts
+    })
+
+    it('allows findAll with orderBy as string', () => {
+      const opts: FindAllOptions<typeof User.fields> = { orderBy: 'name' }
+      void opts
+    })
+
+    it('rejects findAll with nonexistent orderBy field', () => {
+      // @ts-expect-error - 'nonexistent' is not a field
+      const opts: FindAllOptions<typeof User.fields> = { orderBy: 'nonexistent' }
+      void opts
+    })
+
+    it('allows findAll with where as equality object', () => {
+      const opts: FindAllOptions<typeof User.fields> = { where: { email: 'x@example.com' } }
+      void opts
+    })
+
+    it('allows findAll with where as Drizzle SQL expression', () => {
+      const opts: FindAllOptions<typeof User.fields> = {
+        where: like(User.table.email, '%x%'),
+      }
+      void opts
+    })
+
+    it('rejects findAll options that include limit (limit must not be in FindAllOptions)', () => {
+      // @ts-expect-error - limit is not a property of FindAllOptions
+      const opts: FindAllOptions<typeof User.fields> = { limit: 20 }
+      void opts
+    })
+
+    it('findAll return type is Promise<RowType<Fields>[]>', async () => {
+      const result: Promise<RowType<typeof User.fields>[]> = User.findAll({} as Adapter)
+      void result
     })
   })
 

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -3,9 +3,7 @@ import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core'
 import { HTTPException } from 'hono/http-exception'
 import type { Adapter } from '../adapter/types'
 import type { Field } from '../field/types'
-import type { CreateInput, IdOrWhere, OrderBy, RowType, Where } from './types'
-
-const MAX_LIMIT = 100
+import type { CreateInput, FindAllOptions, IdOrWhere, OrderBy, RowType, Where } from './types'
 
 /**
  * Validates and guards limit/offset parameters.
@@ -18,9 +16,6 @@ function guardLimit(limit: unknown): number {
   const n = limit as number
   if (n < 0) {
     throw new HTTPException(400, { message: 'limit must be >= 0' })
-  }
-  if (n > MAX_LIMIT) {
-    throw new HTTPException(400, { message: `limit must be <= ${MAX_LIMIT}` })
   }
   return n
 }
@@ -170,8 +165,86 @@ export async function findManyImpl<
         throw new HTTPException(400, { message: 'invalid orderBy format' })
       }
 
-      // Runtime guard against identifier injection
-      if (!Object.hasOwn(table, column)) {
+      // Runtime guard against identifier injection (both fields and table to match where-clause guard)
+      if (!Object.hasOwn(fields, column) || !Object.hasOwn(table, column)) {
+        throw new HTTPException(400, { message: 'invalid field in orderBy' })
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: table column access is runtime-guarded by hasOwn
+      const col = (table as unknown as Record<string, any>)[column]
+      query = query.orderBy(direction === 'asc' ? asc(col) : desc(col))
+    }
+  }
+
+  const rows = await query
+  return rows
+}
+
+/**
+ * Fetches all rows without a LIMIT clause.
+ * For batch processing / admin tooling. Apply an app-level size guard when used in request handlers.
+ * @internal
+ */
+export async function findAllImpl<
+  // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
+  Fields extends Record<string, Field<any, any, any>>,
+>(
+  adapter: Adapter,
+  table: SQLiteTableWithColumns<any>,
+  fields: Fields,
+  options?: FindAllOptions<Fields>,
+): Promise<RowType<Fields>[]> {
+  const offset = options?.offset !== undefined ? guardOffset(options.offset) : undefined
+
+  // SQLite requires LIMIT when OFFSET is used.
+  // Number.MAX_SAFE_INTEGER is used as a sentinel "no practical limit" value when offset is specified.
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle query builder type narrowing
+  let query: any =
+    offset !== undefined
+      ? adapter.drizzle.select().from(table).limit(Number.MAX_SAFE_INTEGER).offset(offset)
+      : adapter.drizzle.select().from(table)
+
+  // Apply where clause
+  if (options?.where !== undefined) {
+    if (options.where instanceof SQL) {
+      query = query.where(options.where)
+    } else {
+      const whereClause = buildWhereClause(
+        table,
+        fields,
+        options.where as Where<Record<string, any>>,
+      )
+      if (whereClause !== null) {
+        query = query.where(whereClause)
+      }
+    }
+  }
+
+  // Apply ordering
+  if (options?.orderBy !== undefined) {
+    const orderByList = Array.isArray(options.orderBy) ? options.orderBy : [options.orderBy]
+
+    for (const orderByItem of orderByList) {
+      let column: string
+      let direction: 'asc' | 'desc' = 'asc'
+
+      if (typeof orderByItem === 'string') {
+        column = orderByItem
+      } else if (
+        typeof orderByItem === 'object' &&
+        orderByItem !== null &&
+        'column' in orderByItem
+      ) {
+        column = orderByItem.column
+        if (orderByItem.direction) {
+          direction = orderByItem.direction
+        }
+      } else {
+        throw new HTTPException(400, { message: 'invalid orderBy format' })
+      }
+
+      // Runtime guard against identifier injection (both fields and table to match where-clause guard)
+      if (!Object.hasOwn(fields, column) || !Object.hasOwn(table, column)) {
         throw new HTTPException(400, { message: 'invalid field in orderBy' })
       }
 

--- a/packages/nanoka/src/model/define.ts
+++ b/packages/nanoka/src/model/define.ts
@@ -5,13 +5,14 @@ import type { Adapter } from '../adapter/types'
 import type { Field } from '../field/types'
 import { toOpenAPIComponent, toOpenAPISchema } from '../openapi/generate'
 import type { OpenAPIUsage } from '../openapi/types'
-import { createImpl, deleteImpl, findManyImpl, findOneImpl, updateImpl } from './crud'
+import { createImpl, deleteImpl, findAllImpl, findManyImpl, findOneImpl, updateImpl } from './crud'
 import { applySchemaOptions, buildBaseObject, derivePolicyOptions } from './schema'
 import { buildTable } from './table'
 import type {
   Apply,
   CreateInput,
   FieldsToZodShape,
+  FindAllOptions,
   FindManyOptions,
   IdOrWhere,
   Model,
@@ -116,6 +117,10 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
 
     findMany(adapter: Adapter, options: FindManyOptions<Fields>): Promise<RowType<Fields>[]> {
       return findManyImpl(adapter, table, fields, options)
+    },
+
+    findAll(adapter: Adapter, options?: FindAllOptions<Fields>): Promise<RowType<Fields>[]> {
+      return findAllImpl(adapter, table, fields, options)
     },
 
     findOne(adapter: Adapter, idOrWhere: IdOrWhere<Fields>): Promise<RowType<Fields> | null> {

--- a/packages/nanoka/src/model/index.ts
+++ b/packages/nanoka/src/model/index.ts
@@ -2,6 +2,7 @@ export type { OpenAPIModelComponent, OpenAPISchemaObject, OpenAPIUsage } from '.
 export { defineModel } from './define'
 export type {
   CreateInput,
+  FindAllOptions,
   FindManyOptions,
   IdOrWhere,
   Model,

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -25,6 +25,20 @@ export interface FindManyOptions<
 }
 
 /**
+ * Options for findAll query.
+ * No `limit` — issues no LIMIT clause. For batch processing / admin tooling.
+ * Apply an app-level size guard when used in request handlers.
+ */
+export interface FindAllOptions<
+  // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
+  Fields extends Record<string, Field<any, any, any>>,
+> {
+  readonly offset?: number
+  readonly orderBy?: OrderBy<Fields>
+  readonly where?: Where<Fields> | SQL
+}
+
+/**
  * Order-by specification: single field, or field with direction, or array of multiple.
  */
 export type OrderBy<
@@ -612,6 +626,16 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    * const sorted = await User.findMany(adapter, { limit: 10, orderBy: 'name' })
    */
   findMany(adapter: Adapter, options: FindManyOptions<Fields>): Promise<RowType<Fields>[]>
+
+  /**
+   * Fetches all rows without a LIMIT clause.
+   * For batch processing / admin tooling. Apply an app-level size guard when used in request handlers.
+   *
+   * @example
+   * const users = await User.findAll(adapter)
+   * const admins = await User.findAll(adapter, { orderBy: 'name', where: { role: 'admin' } })
+   */
+  findAll(adapter: Adapter, options?: FindAllOptions<Fields>): Promise<RowType<Fields>[]>
 
   /**
    * Fetches a single row by primary key or where clause.


### PR DESCRIPTION
## Summary

- `findMany` の `MAX_LIMIT = 100` ランタイムキャップを廃止。`limit < 0` / 非整数ガードは維持。型レベルの `limit` 必須制約も維持。
- `Model.findAll(adapter, options?)` を追加。`limit` なしで全件取得。`offset` / `orderBy` / `where`（plain object または Drizzle SQL 式）を受け付ける。field policy の適用は既存の `toResponseMany` を使う設計（`findMany` と一貫）。
- `orderBy` の identifier injection guard を `findMany` / `findAll` 両方で `fields && table` の二段階チェックに統一（セキュリティ強化）。
- `llms-full.txt` の `findMany` コード例に `adapter` 引数を追加（AI リファレンスの正確性修正）。
- CHANGELOG の 1.2.0〜1.5.0 欠落エントリを補完。

## Test plan

- [ ] `pnpm -C packages/nanoka test:workers` — Workers 統合テスト 368件 pass
- [ ] `pnpm -C packages/nanoka test:node` — Node テスト 31件 pass
- [ ] `pnpm -C packages/nanoka typecheck` — clean
- [ ] `pnpm lint` — clean

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)