### PR TITLE
fix: NanokaModel に findAll を追加（router 経由で使えなかった問題を修正）

### DIFF
--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -115,6 +115,8 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
 
       findMany: (options) => inner.findMany(adapter, options),
 
+      findAll: (options) => inner.findAll(adapter, options),
+
       findOne: (idOrWhere) => inner.findOne(adapter, idOrWhere),
 
       create: (data) => inner.create(adapter, data),

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -8,6 +8,7 @@ import type {
   Apply,
   CreateInput,
   FieldsToZodShape,
+  FindAllOptions,
   FindManyOptions,
   IdOrWhere,
   ModelTable,
@@ -139,6 +140,12 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
    * `limit` is required (no default) to prevent accidental unbounded queries.
    */
   findMany(options: FindManyOptions<Fields>): Promise<RowType<Fields>[]>
+
+  /**
+   * Fetches all rows without a LIMIT clause.
+   * For batch processing / admin tooling. Apply an app-level size guard when used in request handlers.
+   */
+  findAll(options?: FindAllOptions<Fields>): Promise<RowType<Fields>[]>
 
   /**
    * Fetches a single row by primary key or where clause.


### PR DESCRIPTION
## Summary

#49 で `findAll` を追加したが、`app.model()` 経由で返ってくる `NanokaModel`（`router/types.ts` / `router/nanoka.ts`）への追加が漏れており、通常の使い方では `findAll` が存在しない状態になっていた。

- `NanokaModel` インターフェースに `findAll(options?)` を追加
- `router/nanoka.ts` で `findAll: (options) => inner.findAll(adapter, options)` を wire

## Test plan

- [ ] `pnpm -C packages/nanoka test:workers` — 368件 pass
- [ ] `pnpm -C packages/nanoka typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)