### PR TITLE
test: app.model() 経由の findAll を nanoka.integration.test.ts でカバーする

### DIFF
--- a/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
@@ -293,7 +293,8 @@ describe('nanoka() integration with D1', () => {
       // Call findAll with where filter
       const filtered = await User.findAll({ where: { name: 'User One' } })
       expect(filtered).toHaveLength(1)
-      expect(filtered[0].id).toBe(userId1)
+      // biome-ignore lint/style/noNonNullAssertion: length checked above
+      expect(filtered[0]!.id).toBe(userId1)
     })
   })
 

--- a/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
@@ -288,7 +288,7 @@ describe('nanoka() integration with D1', () => {
 
       // Call findAll with optional orderBy argument
       const orderedUsers = await User.findAll({ orderBy: 'id' })
-      expect(orderedUsers.map(u => u.id)).toEqual([userId1, userId2])
+      expect(orderedUsers.map((u) => u.id)).toEqual([userId1, userId2])
 
       // Call findAll with where filter
       const filtered = await User.findAll({ where: { name: 'User One' } })

--- a/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
@@ -252,6 +252,49 @@ describe('nanoka() integration with D1', () => {
       const shouldBeNull = await User.findOne(userId)
       expect(shouldBeNull).toBeNull()
     })
+
+    it('findAll returns all rows via app.model()', async () => {
+      const { env } = await import('cloudflare:test')
+      const app = nanoka(d1Adapter(env.DB))
+
+      const User = app.model('users', {
+        id: t.uuid().primary(),
+        name: t.string(),
+        email: t.string().email(),
+        passwordHash: t.string(),
+      })
+
+      // Create two users
+      const userId1 = '550e8400-e29b-41d4-a716-446655440007'
+      const userId2 = '550e8400-e29b-41d4-a716-446655440008'
+
+      await User.create({
+        id: userId1,
+        name: 'User One',
+        email: 'user1@example.com',
+        passwordHash: 'hashed1',
+      })
+
+      await User.create({
+        id: userId2,
+        name: 'User Two',
+        email: 'user2@example.com',
+        passwordHash: 'hashed2',
+      })
+
+      // Call findAll without arguments
+      const allUsers = await User.findAll()
+      expect(allUsers).toHaveLength(2)
+
+      // Call findAll with optional orderBy argument
+      const orderedUsers = await User.findAll({ orderBy: 'id' })
+      expect(orderedUsers.map(u => u.id)).toEqual([userId1, userId2])
+
+      // Call findAll with where filter
+      const filtered = await User.findAll({ where: { name: 'User One' } })
+      expect(filtered).toHaveLength(1)
+      expect(filtered[0].id).toBe(userId1)
+    })
   })
 
   describe('validator field type safety', () => {


### PR DESCRIPTION
## Summary

- `src/router/__tests__/nanoka.integration.test.ts` の `model CRUD through app.model` ブロックに `findAll` のテストケースを追加
- `User.findAll()`（引数なし）、`User.findAll({ orderBy: 'id' })`（orderBy）、`User.findAll({ where: { name: ... } })`（where フィルタ）の 3 パターンを確認
- router 層（`router/nanoka.ts` / `router/types.ts`）の wire 漏れを CI で検出できるようになる

## Test plan

- [x] `pnpm -C packages/nanoka test:workers` — 16 files / 369 tests すべて pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)