### PR TITLE
docs: CRUD メソッド追加時に router 層も更新することを CLAUDE.md / AGENTS.md に明記する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,10 @@ For normal implementation work:
 1. Read `docs/implementation-status.md`, `docs/nanoka.md`, the relevant GitHub Issue, and the relevant source files.
 2. Identify whether the task touches shipped API, tracked follow-ups, or historical docs.
 3. Keep changes scoped to the requested task.
-4. Update tests alongside code when behavior or public types change.
-5. Run the narrowest useful verification first, then broader checks when risk warrants it.
-6. Update `docs/implementation-status.md` and/or the GitHub Issue only after the corresponding completion criteria are met.
+4. When adding or removing a CRUD method on the model API, update both layers in the same change: the raw `Model<Fields>` interface in `packages/nanoka/src/model/types.ts` and the bound `NanokaModel<Fields>` interface in `packages/nanoka/src/router/types.ts`, plus the wire-up in `packages/nanoka/src/router/nanoka.ts`. The two-layer split (adapter-first raw API vs. adapter-bound app API) is intentional, and forgetting the router layer makes the new method unreachable from `app.model(...)`.
+5. Update tests alongside code when behavior or public types change.
+6. Run the narrowest useful verification first, then broader checks when risk warrants it.
+7. Update `docs/implementation-status.md` and/or the GitHub Issue only after the corresponding completion criteria are met.
 
 For larger or ambiguous changes, present a short plan before editing. The plan should cover goal, affected files, implementation steps, tests, completion criteria, and deferred scope.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,10 @@ For normal implementation work:
 1. Read `docs/implementation-status.md`, `docs/nanoka.md`, the relevant GitHub Issue, and the relevant source files.
 2. Identify whether the task touches shipped API, tracked follow-ups, or historical docs.
 3. Keep changes scoped to the requested task.
-4. Update tests alongside code when behavior or public types change.
-5. Run the narrowest useful verification first, then broader checks when risk warrants it.
-6. Update `docs/implementation-status.md` and/or the GitHub Issue only after the corresponding completion criteria are met.
+4. When adding or removing a CRUD method on the model API, update both layers in the same change: the raw `Model<Fields>` interface in `packages/nanoka/src/model/types.ts` and the bound `NanokaModel<Fields>` interface in `packages/nanoka/src/router/types.ts`, plus the wire-up in `packages/nanoka/src/router/nanoka.ts`. The two-layer split (adapter-first raw API vs. adapter-bound app API) is intentional, and forgetting the router layer makes the new method unreachable from `app.model(...)`.
+5. Update tests alongside code when behavior or public types change.
+6. Run the narrowest useful verification first, then broader checks when risk warrants it.
+7. Update `docs/implementation-status.md` and/or the GitHub Issue only after the corresponding completion criteria are met.
 
 For larger or ambiguous changes, present a short plan before editing. The plan should cover goal, affected files, implementation steps, tests, completion criteria, and deferred scope.
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` と `AGENTS.md` の Workflow セクションに step 4 を追加し、CRUD メソッド追加時の二層更新ルールを明文化した
- 追記内容: `model/types.ts`（`Model<Fields>`）、`router/types.ts`（`NanokaModel<Fields>`）、`router/nanoka.ts` の wire-up の3箇所を同時更新すること
- 後続ステップを繰り下げて 1〜7 の連番を維持、両ファイルの追記文面を字句レベルで一致させた

## Background

#49 で `findAll` を追加した際、planner のプランに router 層が影響ファイルとして含まれておらず、`router/types.ts` / `router/nanoka.ts` への追加が漏れた（#51 で修正済み）。この種の漏れを防ぐため、エージェント向けガイドラインに明示的なルールを追加する。

## Test plan

- ドキュメントのみの変更のため自動テストなし
- 両ファイルのステップ番号が 1〜7 で連番になっていることを確認済み
- `CLAUDE.md` と `AGENTS.md` の追記文面が字句レベルで一致していることを確認済み

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)