### PR TITLE
feat: docs-site レイアウト・ルーティング実装

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -42,6 +42,11 @@
 
 - `llms.txt` / `llms-full.txt` at repo root, served via GitHub raw URL — [#17](https://github.com/nanokajs/nanoka/issues/17)
 
+### docs-site
+
+- プロジェクト基盤セットアップ（Cloudflare Workers + Hono scaffold） — [#56](https://github.com/nanokajs/nanoka/issues/56)
+- レイアウト・ルーティング実装（HTML レイアウト / サイドバーナビ / ページレジストリ） — [#57](https://github.com/nanokajs/nanoka/issues/57)
+
 ## 未実装として残す（将来候補）
 
 - `findMany` offset 上限 — [#18](https://github.com/nanokajs/nanoka/issues/18)

--- a/site/src/docs-registry.ts
+++ b/site/src/docs-registry.ts
@@ -1,0 +1,120 @@
+type DocSection = 'top' | 'api' | 'guides' | 'cli'
+
+interface DocPage {
+  path: string
+  title: string
+  section: DocSection
+  description?: string
+  content: string
+}
+
+interface NavGroup {
+  label: string
+  section: DocSection
+  pages: DocPage[]
+}
+
+const PLACEHOLDER = '<p>This page is under construction.</p>'
+
+// 15 pages total
+export const docPages: readonly DocPage[] = [
+  {
+    path: '/',
+    title: 'Introduction',
+    section: 'top',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/getting-started',
+    title: 'Getting Started',
+    section: 'top',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/concepts',
+    title: 'Core Concepts',
+    section: 'top',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/field-types',
+    title: 'Field Types',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/field-policies',
+    title: 'Field Policies',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/schema-validator',
+    title: 'Schema & Validator',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/crud',
+    title: 'CRUD Methods',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/response-shaping',
+    title: 'Response Shaping',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/openapi',
+    title: 'OpenAPI',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/escape-hatch',
+    title: 'Escape Hatch',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/api/adapters',
+    title: 'Adapters',
+    section: 'api',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/guides/migration',
+    title: 'Migration Workflow',
+    section: 'guides',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/guides/error-handling',
+    title: 'Error Handling',
+    section: 'guides',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/guides/turso',
+    title: 'Using with Turso',
+    section: 'guides',
+    content: PLACEHOLDER,
+  },
+  {
+    path: '/cli',
+    title: 'CLI Reference',
+    section: 'cli',
+    content: PLACEHOLDER,
+  },
+] satisfies readonly DocPage[]
+
+export const navStructure: NavGroup[] = [
+  { label: '', section: 'top', pages: docPages.filter(p => p.section === 'top') },
+  { label: 'API Reference', section: 'api', pages: docPages.filter(p => p.section === 'api') },
+  { label: 'Guides', section: 'guides', pages: docPages.filter(p => p.section === 'guides') },
+  { label: '', section: 'cli', pages: docPages.filter(p => p.section === 'cli') },
+]
+
+export const docsByPath = new Map(docPages.map((p) => [p.path, p]))

--- a/site/src/docs-registry.ts
+++ b/site/src/docs-registry.ts
@@ -111,10 +111,10 @@ export const docPages: readonly DocPage[] = [
 ] satisfies readonly DocPage[]
 
 export const navStructure: NavGroup[] = [
-  { label: '', section: 'top', pages: docPages.filter(p => p.section === 'top') },
-  { label: 'API Reference', section: 'api', pages: docPages.filter(p => p.section === 'api') },
-  { label: 'Guides', section: 'guides', pages: docPages.filter(p => p.section === 'guides') },
-  { label: '', section: 'cli', pages: docPages.filter(p => p.section === 'cli') },
+  { label: '', section: 'top', pages: docPages.filter((p) => p.section === 'top') },
+  { label: 'API Reference', section: 'api', pages: docPages.filter((p) => p.section === 'api') },
+  { label: 'Guides', section: 'guides', pages: docPages.filter((p) => p.section === 'guides') },
+  { label: '', section: 'cli', pages: docPages.filter((p) => p.section === 'cli') },
 ]
 
 export const docsByPath = new Map(docPages.map((p) => [p.path, p]))

--- a/site/src/index.ts
+++ b/site/src/index.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono'
+import { docPages } from './docs-registry'
+import { renderLayout } from './layout'
 
 type Bindings = {
   ASSETS: Fetcher
@@ -6,6 +8,22 @@ type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings }>()
 
-app.get('/', (c) => c.text('Nanoka docs site (placeholder)'))
+// ドキュメントページを自動登録
+for (const page of docPages) {
+  app.get(page.path, (c) =>
+    c.html(
+      renderLayout({
+        currentPath: page.path,
+        title: page.title,
+        description: page.description,
+        bodyHtml: page.content,
+      })
+    )
+  )
+}
+
+// セクショントップのリダイレクト
+app.get('/api', (c) => c.redirect('/api/field-types', 302))
+app.get('/guides', (c) => c.redirect('/guides/migration', 302))
 
 export default app

--- a/site/src/index.ts
+++ b/site/src/index.ts
@@ -17,8 +17,8 @@ for (const page of docPages) {
         title: page.title,
         description: page.description,
         bodyHtml: page.content,
-      })
-    )
+      }),
+    ),
   )
 }
 

--- a/site/src/layout.ts
+++ b/site/src/layout.ts
@@ -1,0 +1,70 @@
+import { navStructure } from './docs-registry'
+
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function renderSidebar(currentPath: string): string {
+  let items = ''
+  for (const group of navStructure) {
+    if (group.label === '') {
+      for (const page of group.pages) {
+        const isCurrent = page.path === currentPath
+        const attrs = isCurrent ? ' aria-current="page" class="active"' : ''
+        items += `<li><a href="${escapeHtml(page.path)}"${attrs}>${escapeHtml(page.title)}</a></li>\n`
+      }
+    } else {
+      let subItems = ''
+      for (const page of group.pages) {
+        const isCurrent = page.path === currentPath
+        const attrs = isCurrent ? ' aria-current="page" class="active"' : ''
+        subItems += `<li><a href="${escapeHtml(page.path)}"${attrs}>${escapeHtml(page.title)}</a></li>\n`
+      }
+      items += `<li class="nav-group">\n<span class="nav-group-label">${escapeHtml(group.label)}</span>\n<ul>\n${subItems}</ul>\n</li>\n`
+    }
+  }
+  return `<nav class="sidebar">\n<ul>\n${items}</ul>\n</nav>`
+}
+
+/** bodyHtml must be trusted HTML — never pass unsanitized user input */
+export function renderLayout(opts: {
+  currentPath: string
+  title: string
+  description?: string
+  bodyHtml: string
+}): string {
+  const { currentPath, title, description, bodyHtml } = opts
+  const descTag =
+    description !== undefined
+      ? `\n  <meta name="description" content="${escapeHtml(description)}">`
+      : ''
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)} — Nanoka</title>${descTag}
+</head>
+<body>
+  <div class="layout">
+    <header class="site-header">
+      <a href="/" class="site-logo">Nanoka</a>
+    </header>
+    <div class="layout-body">
+      ${renderSidebar(currentPath)}
+      <main class="content">
+        <article>${bodyHtml}</article>
+      </main>
+    </div>
+    <footer class="site-footer">
+      <p>&copy; Nanoka contributors</p>
+    </footer>
+  </div>
+</body>
+</html>`
+}


### PR DESCRIPTION
## Summary

- `site/src/docs-registry.ts` を新規作成 — 15 ページの `docPages`・`navStructure`（4 グループ）・`docsByPath` を一元管理
- `site/src/layout.ts` を新規作成 — `escapeHtml` / `renderSidebar` / `renderLayout` をエクスポート
- `site/src/index.ts` を更新 — `docPages` を反復してルートを自動登録、`/api` → `/api/field-types` と `/guides` → `/guides/migration` の 302 リダイレクトを追加
- `docs/implementation-status.md` に `### docs-site` セクションを追記

## Test plan

- [x] `pnpm -C site typecheck` パス
- [x] `pnpm -C site dev` で全 15 ページが 200 を返すこと
- [x] `/api` → `/api/field-types`、`/guides` → `/guides/migration` に 302 リダイレクトされること
- [x] 各ページのサイドバーで現在ページに `aria-current="page"` が付くこと

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)