### PR TITLE
feat: docs-site スタイリング・レスポンシブ対応 (#59)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -47,6 +47,7 @@
 - プロジェクト基盤セットアップ（Cloudflare Workers + Hono scaffold） — [#56](https://github.com/nanokajs/nanoka/issues/56)
 - レイアウト・ルーティング実装（HTML レイアウト / サイドバーナビ / ページレジストリ） — [#57](https://github.com/nanokajs/nanoka/issues/57)
 - Markdown レンダリング・シンタックスハイライト（marked + marked-highlight + highlight.js、Atom One Dark CSS） — [#58](https://github.com/nanokajs/nanoka/issues/58)
+- スタイリング・レスポンシブ対応（CSS-only ドロワー、タイポグラフィ、OGP メタタグ） — [#59](https://github.com/nanokajs/nanoka/issues/59)
 
 ## 未実装として残す（将来候補）
 

--- a/site/public/styles.css
+++ b/site/public/styles.css
@@ -1,0 +1,350 @@
+:root {
+  --color-bg: #1e1e1e;
+  --color-surface: #282c34;
+  --color-border: #3e4451;
+  --color-text: #e0e0e0;
+  --color-muted: #9aa0a6;
+  --color-accent: #61afef;
+  --color-accent-hover: #82c0ff;
+  --color-code-bg: #2c313a;
+  --color-quote-border: #5c6370;
+
+  --sidebar-width: 240px;
+  --header-height: 56px;
+  --content-max-width: 760px;
+
+  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+}
+
+.site-logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.site-logo:hover {
+  color: var(--color-accent);
+}
+
+.layout-body {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  flex: 1;
+}
+
+.sidebar {
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  overflow-y: auto;
+  background-color: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 1rem 0;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar a {
+  display: block;
+  padding: 0.5rem 1.5rem;
+  color: var(--color-text);
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.sidebar a[aria-current="page"],
+.sidebar a.active {
+  color: var(--color-accent);
+  background-color: rgba(97, 175, 239, 0.1);
+  border-left: 3px solid var(--color-accent);
+  padding-left: calc(1.5rem - 3px);
+}
+
+.sidebar a:hover {
+  color: var(--color-accent);
+  background-color: rgba(97, 175, 239, 0.05);
+}
+
+.nav-group {
+  margin: 1.5rem 0;
+}
+
+.nav-group-label {
+  display: block;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.nav-group ul {
+  padding-left: 0;
+  margin: 0;
+}
+
+.nav-group ul li a {
+  padding-left: 2rem;
+}
+
+.nav-group ul li a[aria-current="page"],
+.nav-group ul li a.active {
+  padding-left: calc(2rem - 3px);
+}
+
+.content {
+  padding: 2rem;
+  max-width: var(--content-max-width);
+  width: 100%;
+}
+
+.site-footer {
+  background-color: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.875rem;
+  margin-top: auto;
+}
+
+article h1 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.5rem;
+}
+
+article h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 2rem 0 0.75rem;
+}
+
+article h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem;
+}
+
+article h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 1.25rem 0 0.5rem;
+}
+
+article p {
+  margin: 0 0 1rem;
+  line-height: 1.7;
+}
+
+article a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+article a:hover,
+article a:focus-visible {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+article code {
+  background-color: var(--color-code-bg);
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+}
+
+article pre {
+  background-color: var(--color-surface);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+article pre code {
+  background-color: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+article blockquote {
+  border-left: 4px solid var(--color-quote-border);
+  margin: 0 0 1rem;
+  padding: 0.5rem 1rem;
+  color: var(--color-muted);
+}
+
+article table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0 0 1rem;
+}
+
+article th,
+article td {
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+article th {
+  background-color: var(--color-surface);
+  font-weight: 600;
+}
+
+article li {
+  margin: 0.25rem 0;
+}
+
+article ol,
+article ul {
+  padding-left: 1.5rem;
+  margin: 0 0 1rem;
+}
+
+article hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 2rem 0;
+}
+
+.sidebar-toggle-input {
+  display: none;
+}
+
+.sidebar-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: 0.25rem;
+  transition: color 0.15s ease;
+}
+
+.sidebar-toggle:hover {
+  color: var(--color-accent);
+}
+
+.sidebar-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background-color: currentColor;
+  margin: 4px 0;
+}
+
+.sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  top: var(--header-height);
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 99;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .layout-body {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    width: var(--sidebar-width);
+    height: calc(100vh - var(--header-height));
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    z-index: 100;
+    border-right: 1px solid var(--color-border);
+  }
+
+  #sidebar-toggle:checked ~ .layout .sidebar {
+    transform: translateX(0);
+  }
+
+  #sidebar-toggle:checked ~ .layout .sidebar-backdrop {
+    display: block;
+  }
+
+  .sidebar-toggle {
+    display: flex;
+  }
+
+  .content {
+    padding: 1.5rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none;
+  }
+}

--- a/site/src/layout.ts
+++ b/site/src/layout.ts
@@ -41,20 +41,28 @@ export function renderLayout(opts: {
   const { currentPath, title, description, bodyHtml } = opts
   const descTag =
     description !== undefined
-      ? `\n  <meta name="description" content="${escapeHtml(description)}">`
+      ? `\n  <meta name="description" content="${escapeHtml(description)}">\n  <meta property="og:description" content="${escapeHtml(description)}">`
       : ''
+  const ogTitle = `${escapeHtml(title)} — Nanoka`
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtml(title)} — Nanoka</title>${descTag}
+  <title>${ogTitle}</title>${descTag}
+  <meta property="og:title" content="${ogTitle}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Nanoka">
+  <meta name="twitter:card" content="summary">
+  <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/highlight.css">
 </head>
 <body>
+  <input type="checkbox" id="sidebar-toggle" class="sidebar-toggle-input">
   <div class="layout">
     <header class="site-header">
       <a href="/" class="site-logo">Nanoka</a>
+      <label for="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></label>
     </header>
     <div class="layout-body">
       ${renderSidebar(currentPath)}
@@ -62,6 +70,7 @@ export function renderLayout(opts: {
         <article>${bodyHtml}</article>
       </main>
     </div>
+    <label for="sidebar-toggle" class="sidebar-backdrop" aria-hidden="true"></label>
     <footer class="site-footer">
       <p>&copy; Nanoka contributors</p>
     </footer>


### PR DESCRIPTION
## Summary

- `site/public/styles.css` を新規作成（CSS-only ダークテーマ）
- サイドバー + コンテンツの 2 カラム CSS Grid レイアウト、サイドバーは sticky スクロール
- サイドバーナビの active ハイライト・グループ階層インデント
- モバイル（≤768px）でサイドバーをドロワー化し、JS 不使用の checkbox + label トグルで開閉
- OGP (`og:title` / `og:type` / `og:site_name` / `og:description`) と `twitter:card` を `layout.ts` に追加
- タイポグラフィ（h1〜h4、p、a、code、pre、blockquote、table、ul/ol）・アクセシビリティ（`:focus-visible`、`prefers-reduced-motion`）

## Test plan

- [x] `pnpm -C site typecheck` がパスすること
- [x] `pnpm -C site dev` でデスクトップ幅（>768px）: 2カラムレイアウト、active ハイライト、グループインデント確認
- [x] モバイル幅（≤768px）: サイドバーが折りたたまれ、ハンバーガーボタンで開閉できること
- [x] `<head>` に OGP メタタグが出力されていること（description あり/なし両ページ）
- [x] コードブロックが highlight.css（Atom One Dark）と視覚的に整合していること

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)