### PR TITLE
feat: docs-site コンテンツ執筆 + EN/JA 言語トグル

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -48,6 +48,7 @@
 - レイアウト・ルーティング実装（HTML レイアウト / サイドバーナビ / ページレジストリ） — [#57](https://github.com/nanokajs/nanoka/issues/57)
 - Markdown レンダリング・シンタックスハイライト（marked + marked-highlight + highlight.js、Atom One Dark CSS） — [#58](https://github.com/nanokajs/nanoka/issues/58)
 - スタイリング・レスポンシブ対応（CSS-only ドロワー、タイポグラフィ、OGP メタタグ） — [#59](https://github.com/nanokajs/nanoka/issues/59)
+- コンテンツ執筆（Introduction / Getting Started / Core Concepts）+ 言語トグル機構（EN/JA） — [#60](https://github.com/nanokajs/nanoka/issues/60)
 
 ## 未実装として残す（将来候補）
 

--- a/site/public/styles.css
+++ b/site/public/styles.css
@@ -348,3 +348,35 @@ article hr {
     transition: none;
   }
 }
+
+/* Language toggle */
+.lang-toggle {
+  display: inline-flex;
+  gap: 0;
+  align-items: center;
+}
+.lang-toggle--hidden {
+  display: none;
+}
+.lang-btn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  line-height: 1.5;
+}
+.lang-btn:first-child {
+  border-radius: 4px 0 0 4px;
+}
+.lang-btn:last-child {
+  border-radius: 0 4px 4px 0;
+  border-left: none;
+}
+.lang-btn[aria-pressed="true"] {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}

--- a/site/src/content/concepts.ts
+++ b/site/src/content/concepts.ts
@@ -1,0 +1,319 @@
+export const contentEn = `\
+# Core Concepts
+
+The design decisions that make Nanoka tick.
+
+## 80% automatic, 20% explicit
+
+Nanoka derives your DB schema, TypeScript types, and base validation from one model definition. That is the automatic 80%. The remaining 20% — what the API accepts, what it returns, how fields are shaped for specific routes — is kept explicit.
+
+The clearest example is \`passwordHash\`:
+
+\`\`\`typescript
+const User = app.model('users', {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(), // DB column, never in API output
+})
+\`\`\`
+
+By marking it \`serverOnly()\`, Nanoka strips it from every response automatically. You do not need to \`omit\` it by hand in every route. The 20% is where you intentionally diverge — for example, a POST /users route that accepts a plain \`password\` field, hashes it, and stores the hash:
+
+\`\`\`typescript
+import { zValidator } from '@hono/zod-validator'
+import { z } from 'zod'
+
+const CreateUserBody = User.inputSchema('create').extend({ password: z.string().min(8) })
+
+app.post('/users', zValidator('json', CreateUserBody), async (c) => {
+  const { password, ...body } = c.req.valid('json')
+  const passwordHash = await hash(password)
+  const user = await User.create({ ...body, passwordHash })
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+This is explicit by design. The framework does not try to guess how you hash passwords.
+
+## Model-centric data flow
+
+\`\`\`
+model definition (app.model)
+        |
+        +---> DB schema (nanoka generate -> Drizzle schema file)
+        |
+        +---> TypeScript types (inferred automatically)
+        |
+        +---> Zod schemas
+        |       +---> inputSchema('create')  -- readOnly fields removed
+        |       +---> inputSchema('update')  -- readOnly fields removed, all optional
+        |       +---> outputSchema()         -- serverOnly fields removed
+        |
+        +---> Hono validators (User.validator('json', 'create'))
+        |
+        +---> OpenAPI components (User.toOpenAPIComponent())
+\`\`\`
+
+The DB shape and the API shape can diverge intentionally. The model is the bridge, not a mirror.
+
+## Field policy quick reference
+
+| Policy | DB column | Create input | Update input | API output |
+|---|---|---|---|---|
+| (none) | yes | yes | yes | yes |
+| \`readOnly()\` | yes | no | no | yes |
+| \`writeOnly()\` | yes | yes | yes | no |
+| \`serverOnly()\` | yes | no | no | no |
+
+- **readOnly** — set once (auto-generated UUID, \`createdAt\` timestamps). Not accepted by create or update.
+- **writeOnly** — accepted as input but never returned. Suitable for fields that are stored but must not leak.
+- **serverOnly** — only ever touched by server-side code. Not accepted as input and not returned. Suitable for \`passwordHash\` and similar secrets.
+
+## Why \`schema()\` and \`validator()\` are separate
+
+\`User.schema(opts)\` returns a standalone Zod schema. \`User.validator(target, opts)\` returns a Hono validator middleware.
+
+Keeping them separate lets you use the schema without Hono — in tests, in background workers, or when composing schemas:
+
+\`\`\`typescript
+// Use schema() standalone — no Hono dependency needed
+const CreateSchema = User.schema({ omit: (f) => [f.passwordHash] })
+const parsed = CreateSchema.safeParse(body)
+
+// Use validator() as Hono middleware
+app.post('/users', User.validator('json', { omit: (f) => [f.passwordHash] }), handler)
+\`\`\`
+
+Both accept the field accessor form \`{ pick: (f) => [f.name] }\` so typos become type errors at compile time.
+
+## Hono internalized
+
+Nanoka's router is Hono-compatible. You use Hono patterns throughout:
+
+\`\`\`typescript
+import { HTTPException } from 'hono/http-exception'
+
+app.get('/users/:id', async (c) => {
+  const user = await User.findOne({ id: c.req.param('id') })
+  if (!user) throw new HTTPException(404, { message: 'Not found' })
+  return c.json(User.toResponse(user))
+})
+\`\`\`
+
+Hono middleware, \`c.req.valid()\`, \`c.env\`, and the RPC client all work without any adapter layer.
+
+## The Drizzle escape hatch
+
+When the model API is not enough, drop down to raw Drizzle:
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const rows = await app.db
+  .select()
+  .from(User.table)
+  .where(eq(User.table.email, 'alice@example.com'))
+  .limit(1)
+
+// Raw DB rows include all columns including serverOnly fields.
+// Always pass through toResponse / toResponseMany before returning.
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+\`app.db\` is a standard Drizzle instance. Any Drizzle feature — joins, aggregates, raw SQL — works here.
+
+## No custom migration engine
+
+\`nanoka generate\` reads your model definition and writes a Drizzle schema TypeScript file. That is all it does. The diff-to-SQL step and the apply step are delegated to \`drizzle-kit\` and \`wrangler d1 migrations\`:
+
+\`\`\`
+app.model(...)  -->  nanoka generate  -->  src/db/schema.ts
+                                              |
+                              drizzle-kit generate  -->  migrations/*.sql
+                                              |
+                      wrangler d1 migrations apply  -->  D1 database
+\`\`\`
+
+This design means Nanoka never needs to maintain its own migration diffing logic or SQL dialect support. You get the full power of the existing toolchain without Nanoka standing in the way.
+
+## \`findMany\` requires \`limit\`
+
+Calling \`findMany\` without a \`limit\` is a TypeScript type error. This is intentional: unbounded queries against a production database are a common accidental mistake.
+
+\`\`\`typescript
+// Type error — limit is required
+await User.findMany({ offset: 0 })
+
+// Correct
+await User.findMany({ limit: 20, offset: 0 })
+\`\`\`
+
+When you genuinely need all rows — for example, in a background job or a data export — use \`findAll\`:
+
+\`\`\`typescript
+const allUsers = await User.findAll()
+\`\`\`
+
+\`findAll\` makes the intent explicit. Use it knowingly, not as a default.
+`
+
+export const contentJa = `\
+# Core Concepts
+
+Nanoka の設計判断を説明します。
+
+## 80% 自動、20% 明示
+
+Nanoka は 1 つのモデル定義から DB スキーマ・TypeScript 型・基本バリデーションを派生させます。これが自動の 80% です。残りの 20% — API が受け取る内容・返す内容・特定ルートでのフィールド整形 — は明示的に書きます。
+
+最もわかりやすい例が \`passwordHash\` です:
+
+\`\`\`typescript
+const User = app.model('users', {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(), // DB カラム、API レスポンスには絶対に含まれない
+})
+\`\`\`
+
+\`serverOnly()\` を付けると、Nanoka はすべてのレスポンスから自動的に除外します。各ルートで手動で \`omit\` する必要はありません。20% とは意図的に diverge する部分です。例えば POST /users ルートで平文の \`password\` フィールドを受け取り、ハッシュして保存する場合:
+
+\`\`\`typescript
+import { zValidator } from '@hono/zod-validator'
+import { z } from 'zod'
+
+const CreateUserBody = User.inputSchema('create').extend({ password: z.string().min(8) })
+
+app.post('/users', zValidator('json', CreateUserBody), async (c) => {
+  const { password, ...body } = c.req.valid('json')
+  const passwordHash = await hash(password)
+  const user = await User.create({ ...body, passwordHash })
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+これは設計的に明示的です。フレームワークがパスワードのハッシュ方法を推測しようとしません。
+
+## モデル中心のデータフロー
+
+\`\`\`
+モデル定義 (app.model)
+        |
+        +---> DB スキーマ (nanoka generate -> Drizzle スキーマファイル)
+        |
+        +---> TypeScript 型 (自動推論)
+        |
+        +---> Zod スキーマ
+        |       +---> inputSchema('create')  -- readOnly フィールド除外
+        |       +---> inputSchema('update')  -- readOnly フィールド除外、全て任意
+        |       +---> outputSchema()         -- serverOnly フィールド除外
+        |
+        +---> Hono バリデータ (User.validator('json', 'create'))
+        |
+        +---> OpenAPI コンポーネント (User.toOpenAPIComponent())
+\`\`\`
+
+DB の形と API の形は意図的に diverge できます。モデルはミラーではなく橋渡し役です。
+
+## フィールドポリシー早見表
+
+| ポリシー | DB カラム | Create 入力 | Update 入力 | API 出力 |
+|---|---|---|---|---|
+| （なし） | ✅ | ✅ | ✅ | ✅ |
+| \`readOnly()\` | ✅ | ❌ | ❌ | ✅ |
+| \`writeOnly()\` | ✅ | ✅ | ✅ | ❌ |
+| \`serverOnly()\` | ✅ | ❌ | ❌ | ❌ |
+
+- **readOnly** — 一度だけ設定（自動生成 UUID・\`createdAt\` タイムスタンプ）。create・update では受け付けません。
+- **writeOnly** — 入力として受け付けますが、返しません。保存はするが漏れてはいけないフィールドに適しています。
+- **serverOnly** — サーバーサイドのコードのみが扱います。入力として受け付けず、返しません。\`passwordHash\` など機密情報に適しています。
+
+## \`schema()\` と \`validator()\` を分ける理由
+
+\`User.schema(opts)\` はスタンドアロンな Zod スキーマを返します。\`User.validator(target, opts)\` は Hono バリデータミドルウェアを返します。
+
+分離することで、Hono なしでスキーマを使えます — テスト・バックグラウンドワーカー・スキーマ合成など:
+
+\`\`\`typescript
+// schema() をスタンドアロンで使用 — Hono 依存不要
+const CreateSchema = User.schema({ omit: (f) => [f.passwordHash] })
+const parsed = CreateSchema.safeParse(body)
+
+// validator() を Hono ミドルウェアとして使用
+app.post('/users', User.validator('json', { omit: (f) => [f.passwordHash] }), handler)
+\`\`\`
+
+どちらもフィールドアクセサ形式 \`{ pick: (f) => [f.name] }\` に対応しており、タイポがコンパイル時の型エラーになります。
+
+## Hono を内包
+
+Nanoka のルーターは Hono 互換です。Hono のパターンをそのまま使えます:
+
+\`\`\`typescript
+import { HTTPException } from 'hono/http-exception'
+
+app.get('/users/:id', async (c) => {
+  const user = await User.findOne({ id: c.req.param('id') })
+  if (!user) throw new HTTPException(404, { message: 'Not found' })
+  return c.json(User.toResponse(user))
+})
+\`\`\`
+
+Hono ミドルウェア・\`c.req.valid()\`・\`c.env\`・RPC クライアントはアダプター層なしで動作します。
+
+## Drizzle escape hatch
+
+モデル API が足りないときは素の Drizzle に降りられます:
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const rows = await app.db
+  .select()
+  .from(User.table)
+  .where(eq(User.table.email, 'alice@example.com'))
+  .limit(1)
+
+// 生の DB 行には serverOnly フィールドも含む全カラムが含まれます。
+// 返す前に必ず toResponse / toResponseMany を通すこと。
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+\`app.db\` は標準の Drizzle インスタンスです。join・集計・生 SQL など Drizzle のすべての機能が使えます。
+
+## 独自マイグレーションエンジンなし
+
+\`nanoka generate\` はモデル定義を読み取り、Drizzle スキーマの TypeScript ファイルを書き出します。それだけです。差分から SQL への変換と適用は \`drizzle-kit\` と \`wrangler d1 migrations\` に委ねます:
+
+\`\`\`
+app.model(...)  -->  nanoka generate  -->  src/db/schema.ts
+                                              |
+                              drizzle-kit generate  -->  migrations/*.sql
+                                              |
+                      wrangler d1 migrations apply  -->  D1 データベース
+\`\`\`
+
+この設計により、Nanoka は独自のマイグレーション差分ロジックや SQL 方言サポートを維持する必要がありません。既存ツールチェーンのフルパワーを、Nanoka が邪魔することなく使えます。
+
+## \`findMany\` は \`limit\` 必須
+
+\`limit\` なしで \`findMany\` を呼ぶと TypeScript の型エラーになります。これは意図的な設計です。本番 DB への無制限クエリは頻繁に起きる誤りです。
+
+\`\`\`typescript
+// 型エラー — limit が必要
+await User.findMany({ offset: 0 })
+
+// 正しい呼び方
+await User.findMany({ limit: 20, offset: 0 })
+\`\`\`
+
+バックグラウンドジョブやデータエクスポートなど、本当に全件が必要な場合は \`findAll\` を使います:
+
+\`\`\`typescript
+const allUsers = await User.findAll()
+\`\`\`
+
+\`findAll\` は意図を明示します。デフォルトとしてではなく、意識的に使ってください。
+`

--- a/site/src/content/getting-started.ts
+++ b/site/src/content/getting-started.ts
@@ -1,0 +1,371 @@
+export const contentEn = `\
+# Getting Started
+
+Get up and running with Nanoka in minutes.
+
+## 1. Prerequisites
+
+Start from a Hono project targeting Cloudflare Workers:
+
+\`\`\`bash
+npm create hono@latest my-api
+# Select: cloudflare-workers template
+cd my-api
+\`\`\`
+
+## 2. Install dependencies
+
+\`\`\`bash
+pnpm add @nanokajs/core drizzle-orm zod
+pnpm add -D drizzle-kit @cloudflare/workers-types
+\`\`\`
+
+## 3. Configure TypeScript
+
+Add the Cloudflare Workers types to \`tsconfig.json\`:
+
+\`\`\`jsonc
+{
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}
+\`\`\`
+
+## 4. Define a model
+
+Create \`src/models/user.ts\`:
+
+\`\`\`typescript
+import { t } from '@nanokajs/core'
+
+export const userTableName = 'users'
+
+export const userFields = {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email().unique(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(),
+  createdAt:    t.timestamp().readOnly(),
+}
+\`\`\`
+
+- \`readOnly()\` — excluded from create/update inputs; UUID is auto-generated on \`create()\`.
+- \`serverOnly()\` — stored in the DB but never included in API responses.
+
+## 5. Create nanoka.config.ts
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { userFields, userTableName } from './src/models/user'
+
+export default defineConfig({
+  models: [{ name: userTableName, fields: userFields }],
+  output: './drizzle/schema.ts',
+})
+\`\`\`
+
+## 6. Generate the Drizzle schema
+
+\`\`\`bash
+npx nanoka generate
+\`\`\`
+
+This writes \`src/db/schema.ts\` — a standard Drizzle schema file you can inspect and commit.
+
+## 7. Create drizzle.config.ts
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './migrations',
+  dialect: 'sqlite',
+  driver: 'd1-http',
+})
+\`\`\`
+
+## 8. Apply migrations
+
+**Option A — unified pipeline (recommended):**
+
+\`\`\`bash
+# Generate schema, run drizzle-kit, and apply to local D1 in one command
+npx nanoka generate --apply --db <DATABASE_NAME>
+
+# Apply to remote D1
+npx nanoka generate --apply --db <DATABASE_NAME> --remote
+\`\`\`
+
+**Option B — step by step:**
+
+\`\`\`bash
+# 1. Generate Drizzle schema
+npx nanoka generate
+
+# 2. Generate SQL migration files
+npx drizzle-kit generate
+
+# 3a. Apply locally
+npx wrangler d1 migrations apply <DATABASE_NAME> --local
+
+# 3b. Apply to remote
+npx wrangler d1 migrations apply <DATABASE_NAME> --remote
+\`\`\`
+
+## 9. Minimal src/index.ts
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+import { userFields, userTableName } from './models/user'
+
+export interface Env {
+  DB: D1Database
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const app = nanoka<{ Bindings: Env }>(d1Adapter(env.DB))
+    const User = app.model(userTableName, userFields)
+
+    app.get('/users', async (c) => {
+      const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+      return c.json(User.toResponseMany(users))
+    })
+
+    app.post('/users', User.validator('json', 'create'), async (c) => {
+      const body = c.req.valid('json')
+      const user = await User.create(body)
+      return c.json(User.toResponse(user), 201)
+    })
+
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+## 10. Add D1 binding to wrangler.jsonc
+
+\`\`\`jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "<DATABASE_NAME>",
+      "database_id": "<DATABASE_ID>"
+    }
+  ]
+}
+\`\`\`
+
+Create the database if you haven't already:
+
+\`\`\`bash
+npx wrangler d1 create <DATABASE_NAME>
+\`\`\`
+
+## 11. Start the local dev server
+
+\`\`\`bash
+pnpm dev
+\`\`\`
+
+Wrangler starts a local D1 instance automatically. Hit \`http://localhost:8787/users\` to verify.
+
+## 12. Scaffold a full project instantly
+
+To skip all the manual setup above, use the interactive scaffolder:
+
+\`\`\`bash
+pnpm create nanoka-app my-app
+\`\`\`
+
+This generates a ready-to-run project with a User model, migrations config, Wrangler config, and all dependencies pre-configured.
+`
+
+export const contentJa = `\
+# Getting Started
+
+数分で Nanoka を動かしましょう。
+
+## 1. 前提条件
+
+Cloudflare Workers 向け Hono プロジェクトから始めます:
+
+\`\`\`bash
+npm create hono@latest my-api
+# テンプレート: cloudflare-workers を選択
+cd my-api
+\`\`\`
+
+## 2. 依存パッケージのインストール
+
+\`\`\`bash
+pnpm add @nanokajs/core drizzle-orm zod
+pnpm add -D drizzle-kit @cloudflare/workers-types
+\`\`\`
+
+## 3. TypeScript の設定
+
+\`tsconfig.json\` に Cloudflare Workers の型を追加します:
+
+\`\`\`jsonc
+{
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}
+\`\`\`
+
+## 4. モデルを定義する
+
+\`src/models/user.ts\` を作成します:
+
+\`\`\`typescript
+import { t } from '@nanokajs/core'
+
+export const userTableName = 'users'
+
+export const userFields = {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email().unique(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(),
+  createdAt:    t.timestamp().readOnly(),
+}
+\`\`\`
+
+- \`readOnly()\` — create/update 入力から除外されます。UUID は \`create()\` 時に自動生成されます。
+- \`serverOnly()\` — DB には保存されますが、API レスポンスには絶対に含まれません。
+
+## 5. nanoka.config.ts を作成する
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { userFields, userTableName } from './src/models/user'
+
+export default defineConfig({
+  models: [{ name: userTableName, fields: userFields }],
+  output: './drizzle/schema.ts',
+})
+\`\`\`
+
+## 6. Drizzle スキーマを生成する
+
+\`\`\`bash
+npx nanoka generate
+\`\`\`
+
+\`src/db/schema.ts\` という標準の Drizzle スキーマファイルが生成されます。確認してコミットできます。
+
+## 7. drizzle.config.ts を作成する
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './migrations',
+  dialect: 'sqlite',
+  driver: 'd1-http',
+})
+\`\`\`
+
+## 8. マイグレーションを適用する
+
+**Option A — 統合パイプライン（推奨）:**
+
+\`\`\`bash
+# スキーマ生成・drizzle-kit 実行・ローカル D1 への適用を 1 コマンドで
+npx nanoka generate --apply --db <DATABASE_NAME>
+
+# リモート D1 への適用
+npx nanoka generate --apply --db <DATABASE_NAME> --remote
+\`\`\`
+
+**Option B — ステップ別実行:**
+
+\`\`\`bash
+# 1. Drizzle スキーマを生成
+npx nanoka generate
+
+# 2. SQL マイグレーションファイルを生成
+npx drizzle-kit generate
+
+# 3a. ローカルへ適用
+npx wrangler d1 migrations apply <DATABASE_NAME> --local
+
+# 3b. リモートへ適用
+npx wrangler d1 migrations apply <DATABASE_NAME> --remote
+\`\`\`
+
+## 9. src/index.ts の最小実装
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+import { userFields, userTableName } from './models/user'
+
+export interface Env {
+  DB: D1Database
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const app = nanoka<{ Bindings: Env }>(d1Adapter(env.DB))
+    const User = app.model(userTableName, userFields)
+
+    app.get('/users', async (c) => {
+      const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+      return c.json(User.toResponseMany(users))
+    })
+
+    app.post('/users', User.validator('json', 'create'), async (c) => {
+      const body = c.req.valid('json')
+      const user = await User.create(body)
+      return c.json(User.toResponse(user), 201)
+    })
+
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+## 10. wrangler.jsonc に D1 バインディングを追加する
+
+\`\`\`jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "<DATABASE_NAME>",
+      "database_id": "<DATABASE_ID>"
+    }
+  ]
+}
+\`\`\`
+
+データベースをまだ作成していない場合は:
+
+\`\`\`bash
+npx wrangler d1 create <DATABASE_NAME>
+\`\`\`
+
+## 11. ローカル開発サーバを起動する
+
+\`\`\`bash
+pnpm dev
+\`\`\`
+
+Wrangler がローカル D1 インスタンスを自動で起動します。\`http://localhost:8787/users\` にアクセスして確認します。
+
+## 12. create-nanoka-app でスキャフォールド
+
+上記の手動セットアップを省略するには、インタラクティブなスキャフォールダを使います:
+
+\`\`\`bash
+pnpm create nanoka-app my-app
+\`\`\`
+
+User モデル・マイグレーション設定・Wrangler 設定・全依存パッケージが設定済みのプロジェクトが生成されます。
+`

--- a/site/src/content/index.ts
+++ b/site/src/content/index.ts
@@ -1,0 +1,149 @@
+export const contentEn = `\
+# Nanoka
+
+> **Stable 1.0.0** — Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1.
+
+Nanoka eliminates the wiring ceremony between Hono, Drizzle, and Zod.
+One model definition becomes your DB schema, TypeScript types, and base validation — while keeping the 20% explicit where it matters.
+
+## Quick look
+
+\`\`\`typescript
+import { nanoka, d1Adapter, t } from '@nanokajs/core'
+
+const app = nanoka(d1Adapter(env.DB))
+
+const User = app.model('users', {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email().unique(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(),
+  createdAt:    t.timestamp().readOnly(),
+})
+
+// GET /users — paginated, safe by default
+app.get('/users', async (c) => {
+  const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+  return c.json(User.toResponseMany(users))
+})
+
+// POST /users — validator derived from the model
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')
+  const user = await User.create(body)
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+## Why Nanoka?
+
+When you use Hono + Drizzle + Zod manually, you end up writing the same field names in three or four places: the Drizzle schema, the Zod validator, the TypeScript type, and sometimes a separate OpenAPI spec. Nanoka makes the model definition the single source of truth and derives the rest.
+
+- **One definition, multiple derivations** — DB schema, TypeScript types, create/update validators, and OpenAPI components all come from the same model.
+- **Field policies instead of hand-rolling omits** — mark a field \`serverOnly()\` and it never appears in output; mark it \`readOnly()\` and it is excluded from create/update inputs automatically.
+- **Hono internalized** — \`c.req.valid('json')\`, \`HTTPException\`, middleware — the full Hono ecosystem works as-is.
+- **Drizzle escape hatch always open** — \`app.db\` gives you raw Drizzle when the abstraction is not enough.
+- **No custom migration engine** — \`nanoka generate\` produces Drizzle schema files; diff generation and migration application stay with \`drizzle-kit\` and \`wrangler d1 migrations\`.
+
+## Positioning
+
+| | Hono | Drizzle | Nanoka |
+|---|---|---|---|
+| Routing | yes | no | yes (Hono internalized) |
+| ORM / queries | no | yes | yes (Drizzle internalized) |
+| Migrations | no | yes | yes (generate + hand-apply) |
+| Validation | partial (Zod separately) | no | yes (derived from model) |
+| Cloudflare Workers | yes | yes | yes |
+| Learning curve | low | medium | **low** |
+
+## Compared to alternatives
+
+| | Nanoka | RedwoodSDK | Prisma |
+|---|---|---|---|
+| Philosophy | API-first / model-first | Full-stack React-first | ORM only |
+| Router | Hono-compatible | RedwoodSDK own | none |
+| DB escape hatch | raw Drizzle | Kysely / raw SQL | Raw SQL |
+| Primary use case | Small APIs fast | Full-stack apps | DB access layer only |
+
+Prisma 7.0 resolved the bundle-size problem and is now Workers-compatible. Nanoka does not compete on bundle size — the difference is the integrated Hono + D1 API-building experience.
+
+## Where to next
+
+- [Getting Started](/getting-started) — install, define a model, run migrations, serve your first route.
+- [Core Concepts](/concepts) — field policies, the 80/20 design, and the Drizzle escape hatch.
+`
+
+export const contentJa = `\
+# Nanoka
+
+> **Stable 1.0.0** — Cloudflare Workers + D1 向け Hono + Drizzle + Zod 薄ラッパー
+
+Nanoka は Hono・Drizzle・Zod の配線作業をなくします。
+1 つのモデル定義から DB スキーマ・TypeScript 型・基本バリデーションが派生し、重要な 20% だけを明示的に書きます。
+
+## クイックルック
+
+\`\`\`typescript
+import { nanoka, d1Adapter, t } from '@nanokajs/core'
+
+const app = nanoka(d1Adapter(env.DB))
+
+const User = app.model('users', {
+  id:           t.uuid().primary().readOnly(),
+  email:        t.string().email().unique(),
+  name:         t.string(),
+  passwordHash: t.string().serverOnly(),
+  createdAt:    t.timestamp().readOnly(),
+})
+
+// GET /users — ページネーション付きで安全
+app.get('/users', async (c) => {
+  const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+  return c.json(User.toResponseMany(users))
+})
+
+// POST /users — モデルから派生したバリデータ
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')
+  const user = await User.create(body)
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+## なぜ Nanoka か
+
+Hono + Drizzle + Zod を手動で繋ぐとき、同じフィールド名を Drizzle スキーマ・Zod バリデータ・TypeScript 型・OpenAPI スペックの 3〜4 箇所に書くことになります。Nanoka はモデル定義を唯一の情報源にして、残りを派生させます。
+
+- **1 つの定義、複数の派生** — DB スキーマ・TypeScript 型・create/update バリデータ・OpenAPI コンポーネントはすべて同じモデルから生成されます。
+- **フィールドポリシーで omit 記述を省く** — \`serverOnly()\` を付けたフィールドはレスポンスに絶対に現れず、\`readOnly()\` を付けると create/update 入力から自動的に除外されます。
+- **Hono を内包** — \`c.req.valid('json')\`・\`HTTPException\`・ミドルウェアなど、Hono エコシステムがそのまま使えます。
+- **Drizzle escape hatch は常に開いている** — 抽象が足りないときは \`app.db\` で素の Drizzle に降りられます。
+- **独自マイグレーションエンジンなし** — \`nanoka generate\` は Drizzle スキーマファイルを生成し、差分生成・適用は \`drizzle-kit\` と \`wrangler d1 migrations\` に委ねます。
+
+## ポジショニング
+
+| | Hono | Drizzle | Nanoka |
+|---|---|---|---|
+| ルーティング | yes | no | yes（Hono 内包） |
+| ORM / クエリ | no | yes | yes（Drizzle 内包） |
+| マイグレーション | no | yes | yes（生成・手動実行） |
+| バリデーション | partial（Zod 別途） | no | yes（モデルから派生） |
+| Cloudflare Workers | yes | yes | yes |
+| 学習コスト | 低 | 中 | **低** |
+
+## 競合との比較
+
+| | Nanoka | RedwoodSDK | Prisma |
+|---|---|---|---|
+| 思想 | API-first / model-first | フルスタック React-first | ORM 単体 |
+| ルーター | Hono 互換 | RedwoodSDK 独自 | なし |
+| DB escape hatch | 素の Drizzle | Kysely / 生 SQL | Raw SQL |
+| 主な用途 | 小規模 API を即作る | フルスタックアプリを組む | DB アクセス層のみ |
+
+Prisma 7.0 でバンドルサイズ問題は解消され Workers 互換になりました。Nanoka はバンドルサイズで競いません——違いは Hono + D1 を統合した API 構築体験にあります。
+
+## 次へ
+
+- [Getting Started](/getting-started) — インストール・モデル定義・マイグレーション・最初のルートを立ち上げます。
+- [Core Concepts](/concepts) — フィールドポリシー・80/20 設計・Drizzle escape hatch について説明します。
+`

--- a/site/src/docs-registry.ts
+++ b/site/src/docs-registry.ts
@@ -1,3 +1,11 @@
+import { contentEn as conceptsEn, contentJa as conceptsJa } from './content/concepts'
+import {
+  contentEn as gettingStartedEn,
+  contentJa as gettingStartedJa,
+} from './content/getting-started'
+import { contentEn as indexEn, contentJa as indexJa } from './content/index'
+import { renderMarkdown } from './markdown'
+
 type DocSection = 'top' | 'api' | 'guides' | 'cli'
 
 interface DocPage {
@@ -6,6 +14,7 @@ interface DocPage {
   section: DocSection
   description?: string
   content: string
+  contentJa?: string
 }
 
 interface NavGroup {
@@ -16,25 +25,40 @@ interface NavGroup {
 
 const PLACEHOLDER = '<p>This page is under construction.</p>'
 
+const indexHtml = renderMarkdown(indexEn)
+const indexHtmlJa = renderMarkdown(indexJa)
+const gettingStartedHtml = renderMarkdown(gettingStartedEn)
+const gettingStartedHtmlJa = renderMarkdown(gettingStartedJa)
+const conceptsHtml = renderMarkdown(conceptsEn)
+const conceptsHtmlJa = renderMarkdown(conceptsJa)
+
 // 15 pages total
 export const docPages: readonly DocPage[] = [
   {
     path: '/',
     title: 'Introduction',
     section: 'top',
-    content: PLACEHOLDER,
+    description: 'Nanoka — Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1.',
+    content: indexHtml,
+    contentJa: indexHtmlJa,
   },
   {
     path: '/getting-started',
     title: 'Getting Started',
     section: 'top',
-    content: PLACEHOLDER,
+    description:
+      'Get started with Nanoka in minutes. Install, define a model, generate migrations, and run your first API.',
+    content: gettingStartedHtml,
+    contentJa: gettingStartedHtmlJa,
   },
   {
     path: '/concepts',
     title: 'Core Concepts',
     section: 'top',
-    content: PLACEHOLDER,
+    description:
+      'Core concepts behind Nanoka: 80% automatic, 20% explicit, field policies, and the model-centric design.',
+    content: conceptsHtml,
+    contentJa: conceptsHtmlJa,
   },
   {
     path: '/api/field-types',

--- a/site/src/index.ts
+++ b/site/src/index.ts
@@ -17,6 +17,7 @@ for (const page of docPages) {
         title: page.title,
         description: page.description,
         bodyHtml: page.content,
+        bodyHtmlJa: page.contentJa,
       }),
     ),
   )

--- a/site/src/layout.ts
+++ b/site/src/layout.ts
@@ -37,13 +37,16 @@ export function renderLayout(opts: {
   title: string
   description?: string
   bodyHtml: string
+  bodyHtmlJa?: string
 }): string {
-  const { currentPath, title, description, bodyHtml } = opts
+  const { currentPath, title, description, bodyHtml, bodyHtmlJa } = opts
   const descTag =
     description !== undefined
       ? `\n  <meta name="description" content="${escapeHtml(description)}">\n  <meta property="og:description" content="${escapeHtml(description)}">`
       : ''
   const ogTitle = `${escapeHtml(title)} — Nanoka`
+  const langToggleClass = bodyHtmlJa ? 'lang-toggle' : 'lang-toggle lang-toggle--hidden'
+  const jaDiv = bodyHtmlJa ? `<div class="lang-ja" lang="ja" hidden>${bodyHtmlJa}</div>` : ''
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -62,12 +65,19 @@ export function renderLayout(opts: {
   <div class="layout">
     <header class="site-header">
       <a href="/" class="site-logo">Nanoka</a>
+      <div class="${langToggleClass}" role="group" aria-label="Language">
+        <button type="button" class="lang-btn" data-lang="en" aria-pressed="true">EN</button>
+        <button type="button" class="lang-btn" data-lang="ja" aria-pressed="false">JA</button>
+      </div>
       <label for="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle navigation"><span></span><span></span><span></span></label>
     </header>
     <div class="layout-body">
       ${renderSidebar(currentPath)}
       <main class="content">
-        <article>${bodyHtml}</article>
+        <article>
+          <div class="lang-en" lang="en">${bodyHtml}</div>
+          ${jaDiv}
+        </article>
       </main>
     </div>
     <label for="sidebar-toggle" class="sidebar-backdrop" aria-hidden="true"></label>
@@ -75,6 +85,30 @@ export function renderLayout(opts: {
       <p>&copy; Nanoka contributors</p>
     </footer>
   </div>
+<script>
+(function() {
+  var saved = localStorage.getItem('nanoka-lang') || 'en';
+  var enDiv = document.querySelector('.lang-en');
+  var jaDiv = document.querySelector('.lang-ja');
+  var btns = document.querySelectorAll('.lang-btn');
+  function applyLang(lang) {
+    document.documentElement.lang = lang;
+    if (enDiv) enDiv.hidden = (lang !== 'en');
+    if (jaDiv) jaDiv.hidden = (lang !== 'ja');
+    btns.forEach(function(b) {
+      b.setAttribute('aria-pressed', b.dataset.lang === lang ? 'true' : 'false');
+    });
+  }
+  if (jaDiv) { applyLang(saved); }
+  btns.forEach(function(b) {
+    b.addEventListener('click', function() {
+      var lang = b.dataset.lang;
+      localStorage.setItem('nanoka-lang', lang);
+      applyLang(lang);
+    });
+  });
+})();
+</script>
 </body>
 </html>`
 }


### PR DESCRIPTION
## Summary

- Introduction / Getting Started / Core Concepts の3ページに英語・日本語コンテンツを追加
- ヘッダに EN/JA トグルボタンを追加し、1ページ内で言語を切り替え可能に
- `localStorage('nanoka-lang')` で言語選択を永続化（デフォルト: EN）
- 日本語訳のないページ（残り12ページ）ではトグルを非表示

## Changes

- `site/src/content/index.ts` — Introduction（英語・日本語）
- `site/src/content/getting-started.ts` — Getting Started 12ステップ（英語・日本語）
- `site/src/content/concepts.ts` — Core Concepts 8トピック（英語・日本語）
- `site/src/docs-registry.ts` — `DocPage.contentJa?: string` 追加、3ページの content 差し替え
- `site/src/layout.ts` — EN/JA トグルボタン・言語ラッパ div・インライン JS 追加
- `site/src/index.ts` — `contentJa` を `renderLayout` に渡すよう変更
- `site/public/styles.css` — `.lang-toggle` / `.lang-btn` スタイル追加

## Test plan

- [ ] `pnpm -C site dev` でローカル起動し、`/`・`/getting-started`・`/concepts` の3ページを確認
- [ ] EN/JA ボタンでコンテンツが切り替わること
- [ ] ページ遷移後も言語選択が維持されること（localStorage）
- [ ] `/api/field-types` 等の未訳ページでトグルが非表示になること
- [ ] typecheck / lint パス済み

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)