### PR TITLE
feat: docs-site API Reference コンテンツ執筆 (#61)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -49,6 +49,7 @@
 - Markdown レンダリング・シンタックスハイライト（marked + marked-highlight + highlight.js、Atom One Dark CSS） — [#58](https://github.com/nanokajs/nanoka/issues/58)
 - スタイリング・レスポンシブ対応（CSS-only ドロワー、タイポグラフィ、OGP メタタグ） — [#59](https://github.com/nanokajs/nanoka/issues/59)
 - コンテンツ執筆（Introduction / Getting Started / Core Concepts）+ 言語トグル機構（EN/JA） — [#60](https://github.com/nanokajs/nanoka/issues/60)
+- API Reference コンテンツ執筆（Field Types / Field Policies / Schema & Validator / CRUD Methods / Response Shaping / OpenAPI / Escape Hatch / Adapters） — [#61](https://github.com/nanokajs/nanoka/issues/61)
 
 ## 未実装として残す（将来候補）
 

--- a/site/src/content/api/adapters.ts
+++ b/site/src/content/api/adapters.ts
@@ -1,0 +1,243 @@
+export const contentEn = `\
+# Adapters
+
+Nanoka routes all database access through an adapter interface. Two adapters are provided out of the box: \`d1Adapter\` for Cloudflare D1 and \`tursoAdapter\` for Turso/libSQL.
+
+## d1Adapter(env.DB)
+
+The D1 adapter is the default choice for Cloudflare Workers. Pass the \`D1Database\` binding from your Worker's environment.
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+
+export interface Env {
+  DB: D1Database
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const app = nanoka<{ Bindings: Env }>(d1Adapter(env.DB))
+    // ...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+Configure the D1 binding in \`wrangler.jsonc\`:
+
+\`\`\`jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-database",
+      "database_id": "<your-database-id>"
+    }
+  ]
+}
+\`\`\`
+
+Create the database if you haven't already:
+
+\`\`\`bash
+npx wrangler d1 create my-database
+\`\`\`
+
+## tursoAdapter(client)
+
+The Turso adapter supports Turso/libSQL databases. Import from the sub-path export \`@nanokajs/core/turso\`.
+
+\`\`\`typescript
+import { nanoka } from '@nanokajs/core'
+import { tursoAdapter } from '@nanokajs/core/turso'
+import { createClient } from '@libsql/client'
+
+export interface Env {
+  TURSO_URL:       string
+  TURSO_AUTH_TOKEN: string
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const client = createClient({
+      url:       env.TURSO_URL,
+      authToken: env.TURSO_AUTH_TOKEN,
+    })
+
+    const app = nanoka<{ Bindings: Env }>(tursoAdapter(client))
+    // ...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+For local development, use a local SQLite file instead of a remote Turso URL. Use \`file:local.db\` in \`.dev.vars\` and \`libsql://...\` for production:
+
+\`\`\`typescript
+// Local development with a local SQLite file
+import { createClient } from '@libsql/client'
+const client = createClient({ url: 'file:local.db' })
+\`\`\`
+
+\`\`\`
+# .dev.vars — local dev
+TURSO_URL=file:local.db
+TURSO_AUTH_TOKEN=
+
+# Production (set via wrangler secret put)
+# TURSO_URL=libsql://your-db.turso.io
+# TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+## Secret configuration
+
+Store database credentials as Wrangler secrets, not in source code or \`wrangler.jsonc\`.
+
+\`\`\`bash
+# Set secrets for Turso
+npx wrangler secret put TURSO_URL
+npx wrangler secret put TURSO_AUTH_TOKEN
+\`\`\`
+
+For local development, add secrets to \`.dev.vars\` (this file should be in \`.gitignore\`):
+
+\`\`\`
+TURSO_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+D1 database IDs are not secrets and can be committed in \`wrangler.jsonc\`. The D1 database itself is protected by your Cloudflare account credentials.
+
+## D1 vs Turso: choosing an adapter
+
+| Criterion | D1 (Cloudflare) | Turso/libSQL |
+|---|---|---|
+| Primary deployment target | Cloudflare Workers | Cloudflare Workers, Node.js, edge runtimes |
+| Geographic distribution | Cloudflare's global network | Turso's global edge replicas |
+| Pricing model | Included in Workers plans | Turso's own pricing |
+| Local dev | Wrangler local D1 (automatic) | \`libsql\` client in dev mode or local SQLite file |
+| Batch API | D1 batch | Turso batch (same adapter interface) |
+| Production recommendation | Start here for Cloudflare-only apps | Use when you need multi-platform or Turso-specific features |
+`
+
+export const contentJa = `\
+# Adapters
+
+Nanoka はすべてのデータベースアクセスをアダプターインターフェース経由でルーティングします。2 つのアダプターが標準提供されています: Cloudflare D1 向けの \`d1Adapter\` と Turso/libSQL 向けの \`tursoAdapter\` です。
+
+## d1Adapter(env.DB)
+
+D1 アダプターは Cloudflare Workers のデフォルトの選択肢です。Worker の環境から \`D1Database\` バインディングを渡します。
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+
+export interface Env {
+  DB: D1Database
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const app = nanoka<{ Bindings: Env }>(d1Adapter(env.DB))
+    // ...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+\`wrangler.jsonc\` で D1 バインディングを設定します:
+
+\`\`\`jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-database",
+      "database_id": "<your-database-id>"
+    }
+  ]
+}
+\`\`\`
+
+データベースをまだ作成していない場合は:
+
+\`\`\`bash
+npx wrangler d1 create my-database
+\`\`\`
+
+## tursoAdapter(client)
+
+Turso アダプターは Turso/libSQL データベースをサポートします。サブパスエクスポート \`@nanokajs/core/turso\` からインポートします。
+
+\`\`\`typescript
+import { nanoka } from '@nanokajs/core'
+import { tursoAdapter } from '@nanokajs/core/turso'
+import { createClient } from '@libsql/client'
+
+export interface Env {
+  TURSO_URL:        string
+  TURSO_AUTH_TOKEN: string
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const client = createClient({
+      url:       env.TURSO_URL,
+      authToken: env.TURSO_AUTH_TOKEN,
+    })
+
+    const app = nanoka<{ Bindings: Env }>(tursoAdapter(client))
+    // ...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+ローカル開発時はリモートの Turso URL の代わりにローカル SQLite ファイルを使用します。\`.dev.vars\` では \`file:local.db\`、本番では \`libsql://...\` を使い分けます:
+
+\`\`\`typescript
+// ローカル開発: ローカル SQLite ファイルを使用
+import { createClient } from '@libsql/client'
+const client = createClient({ url: 'file:local.db' })
+\`\`\`
+
+\`\`\`
+# .dev.vars — ローカル開発用
+TURSO_URL=file:local.db
+TURSO_AUTH_TOKEN=
+
+# 本番（wrangler secret put で設定）
+# TURSO_URL=libsql://your-db.turso.io
+# TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+## シークレット設定
+
+データベースの認証情報はソースコードや \`wrangler.jsonc\` ではなく、Wrangler のシークレットとして保存します。
+
+\`\`\`bash
+# Turso 用シークレットを設定
+npx wrangler secret put TURSO_URL
+npx wrangler secret put TURSO_AUTH_TOKEN
+\`\`\`
+
+ローカル開発用には \`.dev.vars\` にシークレットを追加します（このファイルは \`.gitignore\` に含めること）:
+
+\`\`\`
+TURSO_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+D1 データベース ID はシークレットではなく、\`wrangler.jsonc\` にコミットできます。D1 データベース自体は Cloudflare アカウントの認証情報で保護されています。
+
+## D1 vs Turso: アダプターの選び方
+
+| 基準 | D1（Cloudflare）| Turso/libSQL |
+|---|---|---|
+| 主要デプロイターゲット | Cloudflare Workers | Cloudflare Workers・Node.js・エッジランタイム |
+| 地理的分散 | Cloudflare のグローバルネットワーク | Turso のグローバルエッジレプリカ |
+| 料金モデル | Workers プランに含まれる | Turso 独自の料金 |
+| ローカル開発 | Wrangler ローカル D1（自動）| dev モードの \`libsql\` クライアントまたはローカル SQLite ファイル |
+| バッチ API | D1 バッチ | Turso バッチ（同じアダプターインターフェース）|
+| 本番推奨 | Cloudflare のみのアプリはここから始める | マルチプラットフォームや Turso 固有の機能が必要な場合 |
+`

--- a/site/src/content/api/crud.ts
+++ b/site/src/content/api/crud.ts
@@ -1,0 +1,387 @@
+export const contentEn = `\
+# CRUD Methods
+
+Nanoka models expose six CRUD methods: \`findMany\`, \`findAll\`, \`findOne\`, \`create\`, \`update\`, and \`delete\`. All methods are bound to the adapter when the model is registered with \`app.model()\`.
+
+## findMany
+
+Fetches multiple rows with pagination. \`limit\` is **required** — omitting it is a TypeScript type error.
+
+\`\`\`typescript
+// Type error — limit is required
+await User.findMany({ offset: 0 })
+//         ^^^^^^^^ Property 'limit' is missing
+
+// Correct
+const users = await User.findMany({ limit: 20, offset: 0 })
+const page2 = await User.findMany({ limit: 20, offset: 20 })
+\`\`\`
+
+**Options:**
+
+\`\`\`typescript
+interface FindManyOptions {
+  limit:    number          // required
+  offset?:  number          // default: 0
+  orderBy?: OrderBy         // optional ordering
+  where?:   Where | SQL     // optional filter
+}
+\`\`\`
+
+**where** — two forms are accepted:
+
+\`\`\`typescript
+// Equality object — each key is AND-combined
+const users = await User.findMany({ limit: 10, where: { isActive: true } })
+
+// Drizzle SQL expression
+import { eq, gt } from 'drizzle-orm'
+const users = await User.findMany({
+  limit: 10,
+  where: gt(User.table.createdAt, cutoff),
+})
+\`\`\`
+
+**orderBy** — three forms are accepted:
+
+\`\`\`typescript
+// Single field name
+await User.findMany({ limit: 10, orderBy: 'name' })
+
+// Field with direction
+await User.findMany({ limit: 10, orderBy: { column: 'createdAt', direction: 'desc' } })
+
+// Multiple fields
+await User.findMany({ limit: 10, orderBy: [{ column: 'name' }, { column: 'createdAt', direction: 'desc' }] })
+\`\`\`
+
+## findAll
+
+Fetches all rows without a LIMIT clause. Use this only in batch processing, data exports, or admin tooling — not in request handlers that could receive unbounded input.
+
+\`\`\`typescript
+const allUsers = await User.findAll()
+const activeUsers = await User.findAll({ where: { isActive: true }, orderBy: 'name' })
+\`\`\`
+
+In request handlers, always prefer \`findMany\` with an explicit limit.
+
+## findOne
+
+Fetches a single row by primary key value or where clause. Returns \`null\` if no row matches.
+
+\`\`\`typescript
+// By primary key value
+const user = await User.findOne('uuid-value')
+
+// By where clause
+const user = await User.findOne({ email: 'alice@example.com' })
+
+// Typical 404 pattern
+import { HTTPException } from 'hono/http-exception'
+
+const user = await User.findOne(c.req.param('id'))
+if (!user) throw new HTTPException(404, { message: 'Not found' })
+return c.json(User.toResponse(user))
+\`\`\`
+
+## create
+
+Creates a new row and returns the full inserted record including any generated defaults (UUID, timestamps).
+
+\`\`\`typescript
+const user = await User.create({
+  email: 'alice@example.com',
+  name:  'Alice',
+})
+// Returns the full row including id (auto-generated UUID) and createdAt
+\`\`\`
+
+The input type is \`CreateInput<Fields>\`:
+
+- \`readOnly\` fields are optional (can be passed by server code, excluded from API input schemas).
+- \`serverOnly\` fields are completely excluded from the type — passing them to \`create()\` is a TypeScript error. Use \`app.db\` directly to write \`serverOnly\` fields.
+- Fields with a \`default\` or marked \`optional\` are optional in the input.
+- All other fields are required.
+
+To write a \`serverOnly\` field like \`passwordHash\`, use the \`app.db\` escape hatch:
+
+\`\`\`typescript
+const passwordHash = await bcrypt.hash(body.password, 10)
+await app.db.insert(User.table).values({ ...body, passwordHash })
+\`\`\`
+
+## update
+
+Updates rows matching the given id or where clause. Returns the updated row, or \`null\` if no row matched.
+
+\`\`\`typescript
+// By primary key value
+const updated = await User.update('uuid-value', { name: 'Bob' })
+
+// By where clause
+const updated = await User.update({ email: 'alice@example.com' }, { name: 'Bob' })
+
+// 404 if not found
+if (!updated) throw new HTTPException(404, { message: 'Not found' })
+return c.json(User.toResponse(updated))
+\`\`\`
+
+## delete
+
+Deletes rows matching the given id or where clause. Returns \`{ deleted: number }\`.
+
+\`\`\`typescript
+const result = await User.delete('uuid-value')
+console.log(result.deleted) // number of deleted rows
+
+// 404 if nothing was deleted
+if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })
+return c.body(null, 204)
+\`\`\`
+
+## Full CRUD route example
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+import { HTTPException } from 'hono/http-exception'
+
+export default {
+  async fetch(req, env, ctx) {
+    const app = nanoka(d1Adapter(env.DB))
+    const User = app.model('users', userFields)
+
+    // GET /users — paginated list
+    app.get('/users', async (c) => {
+      const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+      return c.json(User.toResponseMany(users))
+    })
+
+    // GET /users/:id — single user
+    app.get('/users/:id', async (c) => {
+      const user = await User.findOne(c.req.param('id'))
+      if (!user) throw new HTTPException(404, { message: 'Not found' })
+      return c.json(User.toResponse(user))
+    })
+
+    // POST /users — create
+    app.post('/users', User.validator('json', 'create'), async (c) => {
+      const body = c.req.valid('json')
+      const user = await User.create(body)
+      return c.json(User.toResponse(user), 201)
+    })
+
+    // PATCH /users/:id — partial update
+    app.patch('/users/:id', User.validator('json', 'update'), async (c) => {
+      const body = c.req.valid('json')
+      const updated = await User.update(c.req.param('id'), body)
+      if (!updated) throw new HTTPException(404, { message: 'Not found' })
+      return c.json(User.toResponse(updated))
+    })
+
+    // DELETE /users/:id — delete
+    app.delete('/users/:id', async (c) => {
+      const result = await User.delete(c.req.param('id'))
+      if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })
+      return c.body(null, 204)
+    })
+
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+`
+
+export const contentJa = `\
+# CRUD Methods
+
+Nanoka モデルは 6 つの CRUD メソッドを公開します: \`findMany\`・\`findAll\`・\`findOne\`・\`create\`・\`update\`・\`delete\`。すべてのメソッドは \`app.model()\` でモデルを登録する際にアダプターにバインドされます。
+
+## findMany
+
+ページネーション付きで複数の行を取得します。\`limit\` は**必須**です — 省略すると TypeScript の型エラーになります。
+
+\`\`\`typescript
+// 型エラー — limit が必要
+await User.findMany({ offset: 0 })
+//         ^^^^^^^^ Property 'limit' is missing
+
+// 正しい
+const users = await User.findMany({ limit: 20, offset: 0 })
+const page2 = await User.findMany({ limit: 20, offset: 20 })
+\`\`\`
+
+**オプション:**
+
+\`\`\`typescript
+interface FindManyOptions {
+  limit:    number          // 必須
+  offset?:  number          // デフォルト: 0
+  orderBy?: OrderBy         // 任意の並び替え
+  where?:   Where | SQL     // 任意のフィルタ
+}
+\`\`\`
+
+**where** — 2 つの形式が使えます:
+
+\`\`\`typescript
+// 等値オブジェクト — 各キーは AND で結合される
+const users = await User.findMany({ limit: 10, where: { isActive: true } })
+
+// Drizzle SQL 式
+import { eq, gt } from 'drizzle-orm'
+const users = await User.findMany({
+  limit: 10,
+  where: gt(User.table.createdAt, cutoff),
+})
+\`\`\`
+
+**orderBy** — 3 つの形式が使えます:
+
+\`\`\`typescript
+// フィールド名のみ
+await User.findMany({ limit: 10, orderBy: 'name' })
+
+// 方向付きフィールド
+await User.findMany({ limit: 10, orderBy: { column: 'createdAt', direction: 'desc' } })
+
+// 複数フィールド
+await User.findMany({ limit: 10, orderBy: [{ column: 'name' }, { column: 'createdAt', direction: 'desc' }] })
+\`\`\`
+
+## findAll
+
+LIMIT 句なしで全行を取得します。バッチ処理・データエクスポート・管理ツールのみで使用してください。無制限の入力を受け取る可能性があるリクエストハンドラでは使用しないこと。
+
+\`\`\`typescript
+const allUsers = await User.findAll()
+const activeUsers = await User.findAll({ where: { isActive: true }, orderBy: 'name' })
+\`\`\`
+
+リクエストハンドラでは、常に明示的な limit を持つ \`findMany\` を優先してください。
+
+## findOne
+
+主キーの値または where 句で単一の行を取得します。行が見つからない場合は \`null\` を返します。
+
+\`\`\`typescript
+// 主キーの値で
+const user = await User.findOne('uuid-value')
+
+// where 句で
+const user = await User.findOne({ email: 'alice@example.com' })
+
+// 典型的な 404 パターン
+import { HTTPException } from 'hono/http-exception'
+
+const user = await User.findOne(c.req.param('id'))
+if (!user) throw new HTTPException(404, { message: 'Not found' })
+return c.json(User.toResponse(user))
+\`\`\`
+
+## create
+
+新しい行を作成し、生成されたデフォルト値（UUID・タイムスタンプ）を含む挿入されたレコード全体を返します。
+
+\`\`\`typescript
+const user = await User.create({
+  email: 'alice@example.com',
+  name:  'Alice',
+})
+// id（自動生成 UUID）と createdAt を含む全行を返す
+\`\`\`
+
+入力の型は \`CreateInput<Fields>\` です:
+
+- \`readOnly\` フィールドはオプション（サーバーコードから渡せる。API 入力スキーマからは除外される）。
+- \`serverOnly\` フィールドは型から完全に除外される — \`create()\` に渡すと TypeScript エラーになります。\`serverOnly\` フィールドを書き込む場合は \`app.db\` を直接使用してください。
+- \`default\` を持つまたは \`optional\` とマークされたフィールドはオプション。
+- その他のフィールドはすべて必須。
+
+\`passwordHash\` のような \`serverOnly\` フィールドを書き込む場合は \`app.db\` escape hatch を使います:
+
+\`\`\`typescript
+const passwordHash = await bcrypt.hash(body.password, 10)
+await app.db.insert(User.table).values({ ...body, passwordHash })
+\`\`\`
+
+## update
+
+指定した id または where 句に一致する行を更新します。更新された行を返し、一致する行がなければ \`null\` を返します。
+
+\`\`\`typescript
+// 主キーの値で
+const updated = await User.update('uuid-value', { name: 'Bob' })
+
+// where 句で
+const updated = await User.update({ email: 'alice@example.com' }, { name: 'Bob' })
+
+// 見つからない場合は 404
+if (!updated) throw new HTTPException(404, { message: 'Not found' })
+return c.json(User.toResponse(updated))
+\`\`\`
+
+## delete
+
+指定した id または where 句に一致する行を削除します。\`{ deleted: number }\` を返します。
+
+\`\`\`typescript
+const result = await User.delete('uuid-value')
+console.log(result.deleted) // 削除された行数
+
+// 削除されなかった場合は 404
+if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })
+return c.body(null, 204)
+\`\`\`
+
+## フル CRUD ルート例
+
+\`\`\`typescript
+import { nanoka, d1Adapter } from '@nanokajs/core'
+import { HTTPException } from 'hono/http-exception'
+
+export default {
+  async fetch(req, env, ctx) {
+    const app = nanoka(d1Adapter(env.DB))
+    const User = app.model('users', userFields)
+
+    // GET /users — ページネーション付きリスト
+    app.get('/users', async (c) => {
+      const users = await User.findMany({ limit: 20, offset: 0, orderBy: 'createdAt' })
+      return c.json(User.toResponseMany(users))
+    })
+
+    // GET /users/:id — 単一ユーザー
+    app.get('/users/:id', async (c) => {
+      const user = await User.findOne(c.req.param('id'))
+      if (!user) throw new HTTPException(404, { message: 'Not found' })
+      return c.json(User.toResponse(user))
+    })
+
+    // POST /users — 作成
+    app.post('/users', User.validator('json', 'create'), async (c) => {
+      const body = c.req.valid('json')
+      const user = await User.create(body)
+      return c.json(User.toResponse(user), 201)
+    })
+
+    // PATCH /users/:id — 部分的な更新
+    app.patch('/users/:id', User.validator('json', 'update'), async (c) => {
+      const body = c.req.valid('json')
+      const updated = await User.update(c.req.param('id'), body)
+      if (!updated) throw new HTTPException(404, { message: 'Not found' })
+      return c.json(User.toResponse(updated))
+    })
+
+    // DELETE /users/:id — 削除
+    app.delete('/users/:id', async (c) => {
+      const result = await User.delete(c.req.param('id'))
+      if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })
+      return c.body(null, 204)
+    })
+
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+`

--- a/site/src/content/api/escape-hatch.ts
+++ b/site/src/content/api/escape-hatch.ts
@@ -1,0 +1,279 @@
+export const contentEn = `\
+# Escape Hatch
+
+When the model API does not cover your query needs, \`app.db\` gives you direct access to the full Drizzle API. The escape hatch is intentional and always available.
+
+## app.db
+
+\`app.db\` is a standard Drizzle \`BaseSQLiteDatabase\` instance bound to the adapter. Any Drizzle feature works here.
+
+**SELECT with a WHERE clause:**
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const rows = await app.db
+  .select()
+  .from(User.table)
+  .where(eq(User.table.email, 'alice@example.com'))
+  .limit(1)
+
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+**Aggregation:**
+
+\`\`\`typescript
+import { count } from 'drizzle-orm'
+
+const [{ total }] = await app.db
+  .select({ total: count() })
+  .from(User.table)
+  .where(eq(User.table.isActive, true))
+\`\`\`
+
+## User.table
+
+Each model exposes its Drizzle table via \`.table\`. Use it for column references in raw queries.
+
+\`\`\`typescript
+// Type-safe column access
+User.table.id
+User.table.email
+User.table.createdAt
+\`\`\`
+
+## Warning: always pass raw rows through toResponse / toResponseMany
+
+Raw rows returned by \`app.db\` include every column in the table — including \`serverOnly\` fields like \`passwordHash\`. Always pass them through the response shaper before returning to clients.
+
+\`\`\`typescript
+// WRONG — leaks serverOnly fields
+const rows = await app.db.select().from(User.table)
+return c.json(rows)
+
+// CORRECT
+const rows = await app.db.select().from(User.table)
+return c.json(User.toResponseMany(rows))
+\`\`\`
+
+## Avoid SQL injection
+
+Always use Drizzle's parameterized query API. Drizzle escapes values automatically when you pass them as arguments.
+
+\`\`\`typescript
+// SAFE — parameterized
+import { eq } from 'drizzle-orm'
+await app.db.select().from(User.table).where(eq(User.table.email, userInput))
+
+// DANGEROUS — never interpolate external input into sql.raw()
+import { sql } from 'drizzle-orm'
+await app.db.execute(sql.raw(\`SELECT * FROM users WHERE email = '\${userInput}'\`))
+\`\`\`
+
+Use \`sql\` tagged template (not \`sql.raw()\`) when you need raw SQL fragments — Drizzle still parameterizes tagged-template values.
+
+\`\`\`typescript
+import { sql } from 'drizzle-orm'
+
+// SAFE — sql tagged template parameterizes the value
+await app.db.execute(sql\`SELECT * FROM users WHERE email = \${userInput}\`)
+\`\`\`
+
+## app.batch()
+
+Executes multiple queries in a single D1 batch request (D1's batch API). Useful for writes that must all succeed or fail together at the network level.
+
+\`\`\`typescript
+const [newUser, newPost] = await app.batch([
+  app.db.insert(User.table).values({ id: crypto.randomUUID(), email: 'alice@example.com', name: 'Alice' }).returning(),
+  app.db.insert(Post.table).values({ id: crypto.randomUUID(), title: 'Hello', userId: 'alice-id' }).returning(),
+])
+\`\`\`
+
+Note: D1 batch is not a transaction. If the second query fails, the first may already have been applied. For true transactional semantics, use SQLite transactions via raw SQL or Drizzle's transaction API where supported.
+
+## Relations: using joins manually
+
+Nanoka does not implement \`t.hasMany()\` or \`t.belongsTo()\` (non-goal, see Issue #14). Use Drizzle's join API directly for relational queries.
+
+**Inner join:**
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const results = await app.db
+  .select({
+    user:  User.table,
+    post:  Post.table,
+  })
+  .from(User.table)
+  .innerJoin(Post.table, eq(Post.table.userId, User.table.id))
+  .where(eq(User.table.id, userId))
+\`\`\`
+
+**Left join (include users with no posts):**
+
+\`\`\`typescript
+const results = await app.db
+  .select({
+    user: User.table,
+    post: Post.table,
+  })
+  .from(User.table)
+  .leftJoin(Post.table, eq(Post.table.userId, User.table.id))
+\`\`\`
+
+Remember to pass the user portions of the result through \`User.toResponse()\` before returning.
+
+## When to use the escape hatch
+
+| Use case | Recommendation |
+|---|---|
+| Paginated list, single lookup, create, update, delete | Use model CRUD methods |
+| Complex WHERE with multiple conditions | \`app.db\` with Drizzle SQL operators |
+| JOIN across multiple tables | \`app.db\` with \`.innerJoin()\` / \`.leftJoin()\` |
+| Aggregation (COUNT, SUM, AVG) | \`app.db\` with Drizzle aggregate functions |
+| Full-text search | \`app.db\` with raw SQL fragment |
+| Multiple inserts that must batch | \`app.batch()\` |
+`
+
+export const contentJa = `\
+# Escape Hatch
+
+モデル API がクエリのニーズを満たさない場合、\`app.db\` が完全な Drizzle API への直接アクセスを提供します。escape hatch は意図的なものであり、常に利用可能です。
+
+## app.db
+
+\`app.db\` はアダプターにバインドされた標準の Drizzle \`BaseSQLiteDatabase\` インスタンスです。すべての Drizzle 機能が使えます。
+
+**WHERE 句付き SELECT:**
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const rows = await app.db
+  .select()
+  .from(User.table)
+  .where(eq(User.table.email, 'alice@example.com'))
+  .limit(1)
+
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+**集計:**
+
+\`\`\`typescript
+import { count } from 'drizzle-orm'
+
+const [{ total }] = await app.db
+  .select({ total: count() })
+  .from(User.table)
+  .where(eq(User.table.isActive, true))
+\`\`\`
+
+## User.table
+
+各モデルは Drizzle テーブルを \`.table\` で公開します。raw クエリでのカラム参照に使用します。
+
+\`\`\`typescript
+// 型安全なカラムアクセス
+User.table.id
+User.table.email
+User.table.createdAt
+\`\`\`
+
+## 警告: raw 行は必ず toResponse / toResponseMany に通すこと
+
+\`app.db\` が返す raw 行には、テーブルのすべてのカラムが含まれます — \`passwordHash\` のような \`serverOnly\` フィールドも含めて。クライアントに返す前に必ずレスポンスシェーパーに通してください。
+
+\`\`\`typescript
+// 誤り — serverOnly フィールドが漏れる
+const rows = await app.db.select().from(User.table)
+return c.json(rows)
+
+// 正しい
+const rows = await app.db.select().from(User.table)
+return c.json(User.toResponseMany(rows))
+\`\`\`
+
+## SQL インジェクションを避ける
+
+常に Drizzle のパラメータ化クエリ API を使ってください。引数として渡すと Drizzle が値を自動でエスケープします。
+
+\`\`\`typescript
+// 安全 — パラメータ化
+import { eq } from 'drizzle-orm'
+await app.db.select().from(User.table).where(eq(User.table.email, userInput))
+
+// 危険 — 外部入力を sql.raw() に補間しない
+import { sql } from 'drizzle-orm'
+await app.db.execute(sql.raw(\`SELECT * FROM users WHERE email = '\${userInput}'\`))
+\`\`\`
+
+生の SQL フラグメントが必要な場合は \`sql\` タグ付きテンプレート（\`sql.raw()\` ではなく）を使ってください — Drizzle はタグ付きテンプレートの値も引き続きパラメータ化します。
+
+\`\`\`typescript
+import { sql } from 'drizzle-orm'
+
+// 安全 — sql タグ付きテンプレートは値をパラメータ化する
+await app.db.execute(sql\`SELECT * FROM users WHERE email = \${userInput}\`)
+\`\`\`
+
+## app.batch()
+
+複数のクエリを 1 回の D1 バッチリクエストで実行します（D1 のバッチ API）。ネットワークレベルですべて成功するか失敗するかが必要な書き込みに役立ちます。
+
+\`\`\`typescript
+const [newUser, newPost] = await app.batch([
+  app.db.insert(User.table).values({ id: crypto.randomUUID(), email: 'alice@example.com', name: 'Alice' }).returning(),
+  app.db.insert(Post.table).values({ id: crypto.randomUUID(), title: 'Hello', userId: 'alice-id' }).returning(),
+])
+\`\`\`
+
+注意: D1 バッチはトランザクションではありません。2 番目のクエリが失敗しても、最初のクエリはすでに適用されている可能性があります。真のトランザクションセマンティクスには、サポートされている場合は raw SQL または Drizzle のトランザクション API を通じた SQLite トランザクションを使ってください。
+
+## Relations: 手動での join の扱い
+
+Nanoka は \`t.hasMany()\` や \`t.belongsTo()\` を実装していません（非目標、Issue #14 参照）。リレーショナルクエリには Drizzle の join API を直接使ってください。
+
+**内部結合:**
+
+\`\`\`typescript
+import { eq } from 'drizzle-orm'
+
+const results = await app.db
+  .select({
+    user:  User.table,
+    post:  Post.table,
+  })
+  .from(User.table)
+  .innerJoin(Post.table, eq(Post.table.userId, User.table.id))
+  .where(eq(User.table.id, userId))
+\`\`\`
+
+**左結合（投稿がないユーザーも含む）:**
+
+\`\`\`typescript
+const results = await app.db
+  .select({
+    user: User.table,
+    post: Post.table,
+  })
+  .from(User.table)
+  .leftJoin(Post.table, eq(Post.table.userId, User.table.id))
+\`\`\`
+
+返す前に結果のユーザー部分を \`User.toResponse()\` に通すことを忘れないでください。
+
+## いつ escape hatch を使うか
+
+| ユースケース | 推奨 |
+|---|---|
+| ページネーション付きリスト・単一ルックアップ・作成・更新・削除 | モデル CRUD メソッドを使う |
+| 複数条件を持つ複雑な WHERE | Drizzle SQL オペレーターを使った \`app.db\` |
+| 複数テーブルの JOIN | \`.innerJoin()\` / \`.leftJoin()\` を使った \`app.db\` |
+| 集計（COUNT、SUM、AVG）| Drizzle 集計関数を使った \`app.db\` |
+| 全文検索 | raw SQL フラグメントを使った \`app.db\` |
+| バッチ処理が必要な複数の挿入 | \`app.batch()\` |
+`

--- a/site/src/content/api/field-policies.ts
+++ b/site/src/content/api/field-policies.ts
@@ -1,0 +1,219 @@
+export const contentEn = `\
+# Field Policies
+
+Field policies control where a field appears in the API surface. They are applied at the model level and affect schema derivation, CRUD inputs, and response shaping automatically.
+
+## Policy quick reference
+
+| Policy | DB column | Create input | Update input | API output |
+|---|---|---|---|---|
+| (none) | ✅ | ✅ | ✅ | ✅ |
+| \`readOnly()\` | ✅ | ❌ | ❌ | ✅ |
+| \`writeOnly()\` | ✅ | ✅ | ✅ | ❌ |
+| \`serverOnly()\` | ✅ | ❌ | ❌ | ❌ |
+
+## readOnly()
+
+Use \`readOnly()\` for fields that are set once at creation time and never changed by callers. Typical patterns are auto-generated UUIDs and creation timestamps.
+
+\`\`\`typescript
+const fields = {
+  id:        t.uuid().primary().readOnly(),
+  createdAt: t.timestamp().readOnly().default(() => new Date()),
+}
+\`\`\`
+
+- The field is present in every response.
+- The field is excluded from \`inputSchema('create')\` and \`inputSchema('update')\`.
+- For \`t.uuid().primary().readOnly()\`, Nanoka automatically sets \`$defaultFn(() => crypto.randomUUID())\` so the value is generated on insert.
+
+## writeOnly()
+
+Use \`writeOnly()\` for fields that must be accepted as input but must never appear in responses. A classic example is a field that stores a token or a value derived from user input.
+
+\`\`\`typescript
+const fields = {
+  verificationToken: t.string().writeOnly(),
+}
+\`\`\`
+
+- The field is accepted in \`create\` and \`update\` inputs.
+- The field is stripped from every response by \`toResponse()\` and \`toResponseMany()\`.
+- Note: storing a plain password as \`writeOnly()\` is **not** a secure pattern. Plain passwords must be hashed before storage. Use \`serverOnly()\` for the hash column and accept the plain password through a custom \`extend()\` on \`inputSchema('create')\`.
+
+## serverOnly()
+
+Use \`serverOnly()\` for fields that only server-side code should touch. The field exists in the database but is invisible to external callers from both directions.
+
+\`\`\`typescript
+const fields = {
+  passwordHash: t.string().serverOnly(),
+}
+\`\`\`
+
+- The field is **not** accepted in create or update inputs.
+- The field is **not** present in any response.
+- \`serverOnly\` fields are completely excluded from \`CreateInput<Fields>\`. Passing them to \`User.create()\` is a TypeScript error. To write a \`serverOnly\` field to the database, use the \`app.db\` escape hatch directly.
+
+\`\`\`typescript
+// ❌ serverOnly fields cannot be passed to User.create()
+// await User.create({ ...body, passwordHash })  // TypeScript error
+
+// ✅ Use app.db directly (escape hatch)
+const hash = await bcrypt.hash(body.password, 10)
+await app.db.insert(User.table).values({
+  id: crypto.randomUUID(),
+  email: body.email,
+  name: body.name,
+  passwordHash: hash,
+})
+\`\`\`
+
+## Warning: do not re-inject serverOnly fields via extend()
+
+When extending \`inputSchema('create')\` with a custom Zod shape, do not add the \`serverOnly\` field back to the schema. Doing so would expose the field as an accepted API input, defeating the purpose of \`serverOnly()\`.
+
+\`\`\`typescript
+// BAD — exposes passwordHash as an accepted API input
+const CreateUserBody = User.inputSchema('create').extend({
+  passwordHash: z.string(),  // never do this
+})
+
+// GOOD — accept plaintext password, hash server-side, write via app.db
+const CreateUserBody = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+
+app.post('/users', zValidator('json', CreateUserBody), async (c) => {
+  const { password, ...body } = c.req.valid('json')
+  const passwordHash = await bcrypt.hash(password, 10)
+  await app.db.insert(User.table).values({ ...body, passwordHash })
+  const user = await User.findOne({ email: body.email })
+  return c.json(User.toResponse(user!), 201)
+})
+\`\`\`
+
+## pick / omit combined with field accessor
+
+When you need to further narrow a schema beyond what policies provide, use the field accessor to get compile-time typo detection:
+
+\`\`\`typescript
+// Typo here is a type error, not a silent runtime miss
+const PatchSchema = User.schema({ pick: (f) => [f.name, f.email] })
+
+// Same for omit
+const ResponseSchema = User.outputSchema({ omit: (f) => [f.createdAt] })
+\`\`\`
+
+The field accessor \`f\` maps each field name to itself as a string literal, so \`f.nme\` or \`f.emails\` would fail to type-check immediately.
+`
+
+export const contentJa = `\
+# Field Policies
+
+フィールドポリシーは、フィールドが API サーフェスのどこに現れるかを制御します。モデルレベルで適用され、スキーマ派生・CRUD 入力・レスポンス整形に自動的に影響します。
+
+## ポリシー早見表
+
+| ポリシー | DB カラム | Create 入力 | Update 入力 | API 出力 |
+|---|---|---|---|---|
+| （なし） | ✅ | ✅ | ✅ | ✅ |
+| \`readOnly()\` | ✅ | ❌ | ❌ | ✅ |
+| \`writeOnly()\` | ✅ | ✅ | ✅ | ❌ |
+| \`serverOnly()\` | ✅ | ❌ | ❌ | ❌ |
+
+## readOnly()
+
+作成時に一度設定され、呼び出し側によって変更されることのないフィールドに使用します。典型的なパターンは自動生成 UUID と作成タイムスタンプです。
+
+\`\`\`typescript
+const fields = {
+  id:        t.uuid().primary().readOnly(),
+  createdAt: t.timestamp().readOnly().default(() => new Date()),
+}
+\`\`\`
+
+- フィールドはすべてのレスポンスに含まれます。
+- フィールドは \`inputSchema('create')\` および \`inputSchema('update')\` から除外されます。
+- \`t.uuid().primary().readOnly()\` の場合、Nanoka が自動的に \`$defaultFn(() => crypto.randomUUID())\` を設定するため、挿入時に値が生成されます。
+
+## writeOnly()
+
+入力として受け付けるが、レスポンスには絶対に含めてはならないフィールドに使用します。トークンやユーザー入力から派生した値を保存するフィールドが典型例です。
+
+\`\`\`typescript
+const fields = {
+  verificationToken: t.string().writeOnly(),
+}
+\`\`\`
+
+- フィールドは \`create\` および \`update\` 入力で受け付けられます。
+- フィールドは \`toResponse()\` および \`toResponseMany()\` によってすべてのレスポンスから除去されます。
+- 注意: 平文パスワードを \`writeOnly()\` として保存することは**安全ではありません**。平文パスワードは保存前にハッシュ化が必要です。ハッシュカラムには \`serverOnly()\` を使い、平文パスワードは \`inputSchema('create')\` への \`extend()\` で別途受け付けてください。
+
+## serverOnly()
+
+サーバーサイドのコードのみが扱うべきフィールドに使用します。フィールドはデータベースに存在しますが、外部の呼び出し側からは双方向に不可視です。
+
+\`\`\`typescript
+const fields = {
+  passwordHash: t.string().serverOnly(),
+}
+\`\`\`
+
+- フィールドは create または update 入力で**受け付けられません**。
+- フィールドはどのレスポンスにも**含まれません**。
+- \`serverOnly\` フィールドは \`CreateInput<Fields>\` から完全に除外されます。\`User.create()\` に渡すと TypeScript エラーになります。DB に書き込むには \`app.db\` escape hatch を直接使用してください。
+
+\`\`\`typescript
+// ❌ serverOnly フィールドは User.create() に渡せない
+// await User.create({ ...body, passwordHash })  // TypeScript エラー
+
+// ✅ app.db を直接使う（escape hatch）
+const hash = await bcrypt.hash(body.password, 10)
+await app.db.insert(User.table).values({
+  id: crypto.randomUUID(),
+  email: body.email,
+  name: body.name,
+  passwordHash: hash,
+})
+\`\`\`
+
+## 注意: extend() で serverOnly フィールドを再注入しない
+
+\`inputSchema('create')\` をカスタム Zod シェイプで拡張する場合、\`serverOnly\` フィールドをスキーマに戻してはいけません。そうすると、フィールドが受け入れ可能な API 入力として公開され、\`serverOnly()\` の目的が失われます。
+
+\`\`\`typescript
+// 悪い例 — passwordHash を受け入れ可能な API 入力として公開してしまう
+const CreateUserBody = User.inputSchema('create').extend({
+  passwordHash: z.string(),  // 絶対にやらない
+})
+
+// 良い例 — 平文パスワードを受け取り、サーバーサイドでハッシュ化して app.db で書き込む
+const CreateUserBody = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+
+app.post('/users', zValidator('json', CreateUserBody), async (c) => {
+  const { password, ...body } = c.req.valid('json')
+  const passwordHash = await bcrypt.hash(password, 10)
+  await app.db.insert(User.table).values({ ...body, passwordHash })
+  const user = await User.findOne({ email: body.email })
+  return c.json(User.toResponse(user!), 201)
+})
+\`\`\`
+
+## フィールドアクセサと pick / omit の組み合わせ
+
+ポリシーが提供する以上にスキーマをさらに絞り込む必要がある場合は、フィールドアクセサを使うことでコンパイル時のタイポ検出が得られます:
+
+\`\`\`typescript
+// ここでのタイポは型エラーになり、サイレントな runtime ミスにならない
+const PatchSchema = User.schema({ pick: (f) => [f.name, f.email] })
+
+// omit でも同様
+const ResponseSchema = User.outputSchema({ omit: (f) => [f.createdAt] })
+\`\`\`
+
+フィールドアクセサ \`f\` は各フィールド名を文字列リテラルとして自身にマッピングするため、\`f.nme\` や \`f.emails\` のようなタイポは即座に型チェックエラーになります。
+`

--- a/site/src/content/api/field-types.ts
+++ b/site/src/content/api/field-types.ts
@@ -1,0 +1,243 @@
+export const contentEn = `\
+# Field Types
+
+Nanoka's \`t\` object provides a small set of field builders that map directly to SQLite column types and produce Zod validators. All modifiers are chainable and type-safe.
+
+## Field Types
+
+### t.string()
+
+Maps to a SQLite \`text\` column. Accepts optional \`min\`, \`max\`, and \`email\` validators.
+
+\`\`\`typescript
+import { t } from '@nanokajs/core'
+
+const fields = {
+  name:  t.string().min(1).max(255),
+  email: t.string().email(),
+  bio:   t.string().optional(),
+}
+\`\`\`
+
+### t.uuid()
+
+Maps to a SQLite \`text\` column. When combined with \`.primary().readOnly()\`, Nanoka automatically sets \`$defaultFn(() => crypto.randomUUID())\` on the Drizzle column — you never need to generate the ID manually.
+
+\`\`\`typescript
+const fields = {
+  id: t.uuid().primary().readOnly(),
+}
+\`\`\`
+
+Because \`readOnly()\` excludes the field from \`create\` and \`update\` inputs, callers cannot supply an \`id\`. The UUID is generated server-side on every \`create()\` call.
+
+### t.integer()
+
+Maps to a SQLite \`integer\` column. The Zod validator enforces integer values (\`z.number().int()\`).
+
+\`\`\`typescript
+const fields = {
+  age:  t.integer().min(0).max(150),
+  rank: t.integer().optional(),
+}
+\`\`\`
+
+### t.number()
+
+Maps to a SQLite \`real\` column. Accepts floating-point values.
+
+\`\`\`typescript
+const fields = {
+  price:  t.number().min(0),
+  rating: t.number().min(0).max(5),
+}
+\`\`\`
+
+### t.boolean()
+
+Maps to a SQLite \`integer({ mode: 'boolean' })\` column. Drizzle handles the 0/1 ↔ true/false conversion automatically.
+
+\`\`\`typescript
+const fields = {
+  isActive: t.boolean().default(true),
+  isAdmin:  t.boolean().default(false),
+}
+\`\`\`
+
+### t.timestamp()
+
+Maps to a SQLite \`integer({ mode: 'timestamp_ms' })\` column. Values are stored as milliseconds since epoch and returned as \`Date\` objects.
+
+\`\`\`typescript
+const fields = {
+  createdAt: t.timestamp().readOnly().default(() => new Date()),
+  updatedAt: t.timestamp().optional(),
+}
+\`\`\`
+
+### t.json()
+
+Maps to a SQLite \`text({ mode: 'json' })\` column. Two forms are available:
+
+**Type annotation only** — no runtime validation beyond JSON parsing:
+
+\`\`\`typescript
+const fields = {
+  metadata: t.json<{ tags: string[] }>(),
+}
+\`\`\`
+
+**With Zod schema** — runtime validation on every parse:
+
+\`\`\`typescript
+import { z } from 'zod'
+
+const TagsSchema = z.object({ tags: z.array(z.string()) })
+
+const fields = {
+  metadata: t.json(TagsSchema),
+}
+\`\`\`
+
+> **Note:** \`nanoka generate\` always emits \`$type<unknown>()\` in the generated Drizzle schema regardless of which form you use. If you need a typed Drizzle column, edit the generated file manually or add a cast after generation.
+
+## Modifiers
+
+All field builders support the following chainable modifiers:
+
+| Modifier | Effect |
+|---|---|
+| \`.primary()\` | Marks the column as the primary key |
+| \`.unique()\` | Adds a unique constraint |
+| \`.optional()\` | Allows \`undefined\` / \`null\`; removes the \`NOT NULL\` constraint |
+| \`.default(val)\` | Sets a static default value |
+| \`.default(fn)\` | Sets a dynamic default via \`$defaultFn\` |
+| \`.min(n)\` | Minimum string length (string/uuid) or minimum value (number/integer) |
+| \`.max(n)\` | Maximum string length (string/uuid) or maximum value (number/integer) |
+| \`.email()\` | Adds email format validation (string only) |
+| \`.serverOnly()\` | Column exists in DB but is excluded from all API inputs and outputs |
+| \`.writeOnly()\` | Accepted as input but never included in responses |
+| \`.readOnly()\` | Included in responses but excluded from create/update inputs |
+`
+
+export const contentJa = `\
+# Field Types
+
+Nanoka の \`t\` オブジェクトは、SQLite カラム型に直接マッピングされ Zod バリデータを生成するフィールドビルダーを提供します。すべてのモディファイアはチェーン可能で型安全です。
+
+## フィールド型
+
+### t.string()
+
+SQLite の \`text\` カラムにマッピングされます。オプションで \`min\`・\`max\`・\`email\` バリデータを追加できます。
+
+\`\`\`typescript
+import { t } from '@nanokajs/core'
+
+const fields = {
+  name:  t.string().min(1).max(255),
+  email: t.string().email(),
+  bio:   t.string().optional(),
+}
+\`\`\`
+
+### t.uuid()
+
+SQLite の \`text\` カラムにマッピングされます。\`.primary().readOnly()\` と組み合わせると、Nanoka が自動的に \`$defaultFn(() => crypto.randomUUID())\` を Drizzle カラムに設定します — ID を手動で生成する必要はありません。
+
+\`\`\`typescript
+const fields = {
+  id: t.uuid().primary().readOnly(),
+}
+\`\`\`
+
+\`readOnly()\` によりフィールドが \`create\` および \`update\` 入力から除外されるため、呼び出し側は \`id\` を指定できません。UUID はすべての \`create()\` 呼び出し時にサーバーサイドで生成されます。
+
+### t.integer()
+
+SQLite の \`integer\` カラムにマッピングされます。Zod バリデータは整数値（\`z.number().int()\`）を強制します。
+
+\`\`\`typescript
+const fields = {
+  age:  t.integer().min(0).max(150),
+  rank: t.integer().optional(),
+}
+\`\`\`
+
+### t.number()
+
+SQLite の \`real\` カラムにマッピングされます。浮動小数点値を受け付けます。
+
+\`\`\`typescript
+const fields = {
+  price:  t.number().min(0),
+  rating: t.number().min(0).max(5),
+}
+\`\`\`
+
+### t.boolean()
+
+SQLite の \`integer({ mode: 'boolean' })\` カラムにマッピングされます。0/1 ↔ true/false の変換は Drizzle が自動で処理します。
+
+\`\`\`typescript
+const fields = {
+  isActive: t.boolean().default(true),
+  isAdmin:  t.boolean().default(false),
+}
+\`\`\`
+
+### t.timestamp()
+
+SQLite の \`integer({ mode: 'timestamp_ms' })\` カラムにマッピングされます。値はエポックからのミリ秒として保存され、\`Date\` オブジェクトとして返されます。
+
+\`\`\`typescript
+const fields = {
+  createdAt: t.timestamp().readOnly().default(() => new Date()),
+  updatedAt: t.timestamp().optional(),
+}
+\`\`\`
+
+### t.json()
+
+SQLite の \`text({ mode: 'json' })\` カラムにマッピングされます。2 つの形式が使えます:
+
+**型アノテーションのみ** — JSON パース以外の runtime 検証なし:
+
+\`\`\`typescript
+const fields = {
+  metadata: t.json<{ tags: string[] }>(),
+}
+\`\`\`
+
+**Zod スキーマ付き** — 毎回のパース時に runtime 検証:
+
+\`\`\`typescript
+import { z } from 'zod'
+
+const TagsSchema = z.object({ tags: z.array(z.string()) })
+
+const fields = {
+  metadata: t.json(TagsSchema),
+}
+\`\`\`
+
+> **注意:** \`nanoka generate\` は、どちらの形式を使っても生成された Drizzle スキーマには常に \`$type<unknown>()\` を出力します。型付きの Drizzle カラムが必要な場合は、生成後に手動でファイルを編集するかキャストを追加してください。
+
+## モディファイア
+
+すべてのフィールドビルダーは以下のチェーン可能なモディファイアをサポートします:
+
+| モディファイア | 効果 |
+|---|---|
+| \`.primary()\` | カラムを主キーとして設定する |
+| \`.unique()\` | ユニーク制約を追加する |
+| \`.optional()\` | \`undefined\` / \`null\` を許可する。\`NOT NULL\` 制約を削除する |
+| \`.default(val)\` | 静的なデフォルト値を設定する |
+| \`.default(fn)\` | \`$defaultFn\` による動的なデフォルトを設定する |
+| \`.min(n)\` | 文字列の最小長（string/uuid）または最小値（number/integer）|
+| \`.max(n)\` | 文字列の最大長（string/uuid）または最大値（number/integer）|
+| \`.email()\` | メール形式バリデーションを追加する（string のみ）|
+| \`.serverOnly()\` | DB にカラムは存在するが、すべての API 入出力から除外される |
+| \`.writeOnly()\` | 入力として受け付けるが、レスポンスには含めない |
+| \`.readOnly()\` | レスポンスには含まれるが、create/update 入力から除外される |
+`

--- a/site/src/content/api/openapi.ts
+++ b/site/src/content/api/openapi.ts
@@ -1,0 +1,243 @@
+export const contentEn = `\
+# OpenAPI
+
+Nanoka supports generating OpenAPI 3.1 documents from model definitions and route metadata. The generated spec is documentation — it is not used for runtime validation.
+
+## toOpenAPIComponent()
+
+Returns an OpenAPI component object for the model that can be referenced in the spec. Includes all fields with their types and descriptions, with policies applied for output.
+
+\`\`\`typescript
+const component = User.toOpenAPIComponent()
+// { UserOutput: { type: 'object', properties: { ... } } }
+\`\`\`
+
+## toOpenAPISchema(usage)
+
+Returns an OpenAPI schema object for a specific usage context. Three usages are available:
+
+\`\`\`typescript
+// Schema for create request body — readOnly and serverOnly fields excluded
+User.toOpenAPISchema('create')
+
+// Schema for update request body — readOnly and serverOnly excluded, all fields optional
+User.toOpenAPISchema('update')
+
+// Schema for response body — serverOnly and writeOnly fields excluded
+User.toOpenAPISchema('output')
+\`\`\`
+
+Use these inline in your route definitions to document request and response shapes:
+
+\`\`\`typescript
+app.post('/users', {
+  openapi: {
+    summary: 'Create user',
+    requestBody: {
+      required: true,
+      content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+    },
+    responses: {
+      '201': {
+        description: 'Created user',
+        content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+      },
+    },
+  },
+}, User.validator('json', 'create'), handler)
+\`\`\`
+
+## app.openapi(metadata)
+
+Registers OpenAPI metadata for a route independently of the route handler. Use this form when you need \`c.req.valid()\` to retain its inferred type in the handler.
+
+\`\`\`typescript
+app.openapi({
+  method: 'post',
+  path: '/users',
+  summary: 'Create user',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+  },
+  responses: {
+    '201': { description: 'Created user' },
+  },
+})
+
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')  // type is properly inferred here
+  const user = await User.create(body)
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+## Known limitation: inline { openapi } loses c.req.valid type inference
+
+When you pass \`{ openapi: ... }\` as the second argument to \`app.get()\` / \`app.post()\` / etc., the handler's \`c.req.valid()\` loses its inferred type. This is because the inline form uses a variadic \`H[]\` overload that does not thread the validator's type through to the handler.
+
+\`\`\`typescript
+// Inline form — c.req.valid loses type inference
+app.post('/users', { openapi: { ... } }, User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')  // type is 'unknown' here
+  // Must cast explicitly:
+  const body2 = (c.req.valid as (t: 'json') => { email: string; name: string })('json')
+})
+\`\`\`
+
+**Recommendation:** use \`app.openapi()\` + a separate route definition when full handler type inference is required.
+
+## app.generateOpenAPISpec(options)
+
+Builds the full OpenAPI 3.1 document from all registered metadata. Mount the result at \`/openapi.json\`:
+
+\`\`\`typescript
+app.get('/openapi.json', (c) =>
+  c.json(
+    app.generateOpenAPISpec({
+      info: { title: 'My API', version: '1.0.0' },
+    }),
+  ),
+)
+\`\`\`
+
+The \`info\` field is required. Optional \`servers\` and \`tags\` can be added.
+
+## swaggerUI({ url, title? })
+
+Mounts a Swagger UI endpoint that reads from the given OpenAPI JSON URL:
+
+\`\`\`typescript
+import { swaggerUI } from '@nanokajs/core'
+
+app.get('/docs', swaggerUI({ url: '/openapi.json', title: 'API Docs' }))
+\`\`\`
+
+Navigate to \`/docs\` to see the interactive API documentation.
+
+## OpenAPI and runtime validation
+
+> **Important:** The OpenAPI spec is documentation only. Runtime validation is always performed by Zod schemas and Hono validators (\`inputSchema()\` / \`outputSchema()\` / \`User.validator()\`). Do not treat the OpenAPI spec as a security boundary.
+`
+
+export const contentJa = `\
+# OpenAPI
+
+Nanoka はモデル定義とルートメタデータから OpenAPI 3.1 ドキュメントの生成をサポートします。生成されたスペックはドキュメントです — runtime バリデーションには使用されません。
+
+## toOpenAPIComponent()
+
+スペック内で参照できるモデルの OpenAPI コンポーネントオブジェクトを返します。ポリシーが output 向けに適用されたすべてのフィールドの型と説明が含まれます。
+
+\`\`\`typescript
+const component = User.toOpenAPIComponent()
+// { UserOutput: { type: 'object', properties: { ... } } }
+\`\`\`
+
+## toOpenAPISchema(usage)
+
+特定の使用コンテキスト向けの OpenAPI スキーマオブジェクトを返します。3 つの usage が使えます:
+
+\`\`\`typescript
+// create リクエストボディ用スキーマ — readOnly と serverOnly フィールドは除外
+User.toOpenAPISchema('create')
+
+// update リクエストボディ用スキーマ — readOnly と serverOnly は除外、全フィールドはオプション
+User.toOpenAPISchema('update')
+
+// レスポンスボディ用スキーマ — serverOnly と writeOnly フィールドは除外
+User.toOpenAPISchema('output')
+\`\`\`
+
+ルート定義でインラインに使って、リクエストとレスポンスの形状をドキュメント化します:
+
+\`\`\`typescript
+app.post('/users', {
+  openapi: {
+    summary: 'Create user',
+    requestBody: {
+      required: true,
+      content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+    },
+    responses: {
+      '201': {
+        description: 'Created user',
+        content: { 'application/json': { schema: User.toOpenAPISchema('output') } },
+      },
+    },
+  },
+}, User.validator('json', 'create'), handler)
+\`\`\`
+
+## app.openapi(metadata)
+
+ルートハンドラとは独立して、ルートの OpenAPI メタデータを登録します。ハンドラ内で \`c.req.valid()\` が型推論を保持する必要がある場合はこの形式を使います。
+
+\`\`\`typescript
+app.openapi({
+  method: 'post',
+  path: '/users',
+  summary: 'Create user',
+  requestBody: {
+    required: true,
+    content: { 'application/json': { schema: User.toOpenAPISchema('create') } },
+  },
+  responses: {
+    '201': { description: 'Created user' },
+  },
+})
+
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')  // ここで型が正しく推論される
+  const user = await User.create(body)
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+## 既知の制限: インライン { openapi } は c.req.valid の型推論を失う
+
+\`app.get()\` / \`app.post()\` などの第 2 引数に \`{ openapi: ... }\` を渡すと、ハンドラの \`c.req.valid()\` が型推論を失います。これはインライン形式がバリデータの型をハンドラまでスレッドしない可変長 \`H[]\` オーバーロードを使うためです。
+
+\`\`\`typescript
+// インライン形式 — c.req.valid が型推論を失う
+app.post('/users', { openapi: { ... } }, User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')  // ここでの型は 'unknown'
+  // 明示的なキャストが必要:
+  const body2 = (c.req.valid as (t: 'json') => { email: string; name: string })('json')
+})
+\`\`\`
+
+**推奨:** ハンドラの型推論が必要な場合は \`app.openapi()\` と別のルート定義を使ってください。
+
+## app.generateOpenAPISpec(options)
+
+登録されたすべてのメタデータから完全な OpenAPI 3.1 ドキュメントを構築します。結果を \`/openapi.json\` で配信します:
+
+\`\`\`typescript
+app.get('/openapi.json', (c) =>
+  c.json(
+    app.generateOpenAPISpec({
+      info: { title: 'My API', version: '1.0.0' },
+    }),
+  ),
+)
+\`\`\`
+
+\`info\` フィールドは必須です。オプションで \`servers\` と \`tags\` を追加できます。
+
+## swaggerUI({ url, title? })
+
+指定した OpenAPI JSON URL から読み込む Swagger UI エンドポイントをマウントします:
+
+\`\`\`typescript
+import { swaggerUI } from '@nanokajs/core'
+
+app.get('/docs', swaggerUI({ url: '/openapi.json', title: 'API Docs' }))
+\`\`\`
+
+\`/docs\` にアクセスするとインタラクティブな API ドキュメントが表示されます。
+
+## OpenAPI と runtime バリデーション
+
+> **重要:** OpenAPI スペックはドキュメントのみです。Runtime バリデーションは常に Zod スキーマと Hono バリデータ（\`inputSchema()\` / \`outputSchema()\` / \`User.validator()\`）によって行われます。OpenAPI スペックをセキュリティ境界として扱わないでください。
+`

--- a/site/src/content/api/response-shaping.ts
+++ b/site/src/content/api/response-shaping.ts
@@ -1,0 +1,177 @@
+export const contentEn = `\
+# Response Shaping
+
+Before returning data to clients, you must pass DB rows through a response shaper. This strips \`serverOnly\` and \`writeOnly\` fields that should never appear in API responses.
+
+## toResponse(row)
+
+Parses a single DB row through \`outputSchema()\` and returns the safe response object. Use this when returning a single record.
+
+\`\`\`typescript
+app.get('/users/:id', async (c) => {
+  const user = await User.findOne(c.req.param('id'))
+  if (!user) throw new HTTPException(404, { message: 'Not found' })
+  return c.json(User.toResponse(user))
+})
+\`\`\`
+
+Equivalent to \`User.outputSchema().parse(user)\`, but slightly more readable in route handlers.
+
+## toResponseMany(rows)
+
+Parses an array of DB rows and returns an array of safe response objects. The \`outputSchema()\` is built once and reused for every element — more efficient than mapping \`toResponse\` over a large array.
+
+\`\`\`typescript
+app.get('/users', async (c) => {
+  const users = await User.findMany({ limit: 20 })
+  return c.json(User.toResponseMany(users))
+})
+\`\`\`
+
+## Always pass app.db results through the shaper
+
+When using \`app.db\` (raw Drizzle), rows are returned as-is from the database and include all columns — including \`serverOnly\` fields like \`passwordHash\`. You must always call \`toResponse\` or \`toResponseMany\` before returning.
+
+\`\`\`typescript
+// Raw Drizzle — row includes ALL columns including serverOnly
+const rows = await app.db.select().from(User.table).where(eq(User.table.email, email)).limit(1)
+
+// REQUIRED: strip serverOnly / writeOnly before returning
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+Skipping the shaper leaks \`passwordHash\` and any other sensitive columns directly to the client.
+
+## Using outputSchema() directly
+
+When you need to parse an array, add additional \`omit\`, or compose the schema further, use \`outputSchema()\` directly:
+
+\`\`\`typescript
+// Parse an array
+import { z } from 'zod'
+const result = z.array(User.outputSchema()).parse(rows)
+
+// Omit additional fields beyond policy defaults
+const result = User.outputSchema({ omit: (f) => [f.createdAt] }).parse(user)
+
+// Compose with other schemas
+const PaginatedUsers = z.object({
+  items: z.array(User.outputSchema()),
+  total: z.number(),
+})
+\`\`\`
+
+## When to use each
+
+\`\`\`
+Have a single raw DB row?
+  └─ Use toResponse(row)
+
+Have an array of raw DB rows?
+  └─ Use toResponseMany(rows)
+
+Need to omit extra fields or compose with other schemas?
+  └─ Use outputSchema() directly
+
+Need to parse an array with additional constraints?
+  └─ z.array(User.outputSchema()).parse(rows)
+\`\`\`
+
+## Fields excluded by outputSchema()
+
+| Policy | Excluded from output? |
+|---|---|
+| \`serverOnly()\` | ✅ Yes — always excluded |
+| \`writeOnly()\` | ✅ Yes — accepted as input, never returned |
+| \`readOnly()\` | ❌ No — safe to return (UUIDs, timestamps) |
+| (none) | ❌ No — regular fields are always returned |
+`
+
+export const contentJa = `\
+# Response Shaping
+
+クライアントにデータを返す前に、DB の行をレスポンスシェーパーに通す必要があります。これにより、API レスポンスに絶対に含めてはいけない \`serverOnly\` および \`writeOnly\` フィールドが除去されます。
+
+## toResponse(row)
+
+単一の DB 行を \`outputSchema()\` でパースして、安全なレスポンスオブジェクトを返します。単一のレコードを返す場合に使用します。
+
+\`\`\`typescript
+app.get('/users/:id', async (c) => {
+  const user = await User.findOne(c.req.param('id'))
+  if (!user) throw new HTTPException(404, { message: 'Not found' })
+  return c.json(User.toResponse(user))
+})
+\`\`\`
+
+\`User.outputSchema().parse(user)\` と等価ですが、ルートハンドラでは少し読みやすいです。
+
+## toResponseMany(rows)
+
+DB 行の配列をパースして、安全なレスポンスオブジェクトの配列を返します。\`outputSchema()\` は一度だけ構築され、すべての要素で再利用されます — 大きな配列で \`toResponse\` をマップするより効率的です。
+
+\`\`\`typescript
+app.get('/users', async (c) => {
+  const users = await User.findMany({ limit: 20 })
+  return c.json(User.toResponseMany(users))
+})
+\`\`\`
+
+## app.db の結果は必ずシェーパーに通す
+
+\`app.db\`（素の Drizzle）を使うと、行はデータベースからそのまま返され、\`passwordHash\` のような \`serverOnly\` フィールドを含む全カラムが含まれます。返す前に必ず \`toResponse\` または \`toResponseMany\` を呼び出してください。
+
+\`\`\`typescript
+// 素の Drizzle — serverOnly を含む全カラムが行に含まれる
+const rows = await app.db.select().from(User.table).where(eq(User.table.email, email)).limit(1)
+
+// 必須: 返す前に serverOnly / writeOnly を除去する
+return c.json(User.toResponse(rows[0]))
+\`\`\`
+
+シェーパーを省略すると、\`passwordHash\` やその他の機密カラムが直接クライアントに漏れます。
+
+## outputSchema() を直接使う
+
+配列をパースしたり、追加の \`omit\` を加えたり、スキーマをさらに組み合わせる必要がある場合は、\`outputSchema()\` を直接使います:
+
+\`\`\`typescript
+// 配列をパース
+import { z } from 'zod'
+const result = z.array(User.outputSchema()).parse(rows)
+
+// ポリシーのデフォルトを超えて追加フィールドを除外
+const result = User.outputSchema({ omit: (f) => [f.createdAt] }).parse(user)
+
+// 他のスキーマと組み合わせる
+const PaginatedUsers = z.object({
+  items: z.array(User.outputSchema()),
+  total: z.number(),
+})
+\`\`\`
+
+## どれをいつ使うか
+
+\`\`\`
+単一の生の DB 行がある？
+  └─ toResponse(row) を使う
+
+生の DB 行の配列がある？
+  └─ toResponseMany(rows) を使う
+
+追加フィールドの除外や他のスキーマとの合成が必要？
+  └─ outputSchema() を直接使う
+
+追加制約付きで配列をパースする必要がある？
+  └─ z.array(User.outputSchema()).parse(rows)
+\`\`\`
+
+## outputSchema() が除外するフィールド
+
+| ポリシー | 出力から除外？ |
+|---|---|
+| \`serverOnly()\` | ✅ はい — 常に除外 |
+| \`writeOnly()\` | ✅ はい — 入力として受け付けるが、返さない |
+| \`readOnly()\` | ❌ いいえ — 返しても安全（UUID・タイムスタンプ）|
+| （なし） | ❌ いいえ — 通常フィールドは常に返される |
+`

--- a/site/src/content/api/schema-validator.ts
+++ b/site/src/content/api/schema-validator.ts
@@ -1,0 +1,313 @@
+export const contentEn = `\
+# Schema & Validator
+
+Nanoka provides two related but separate APIs for working with Zod schemas: \`schema()\` / \`inputSchema()\` / \`outputSchema()\` return standalone Zod objects, while \`validator()\` wraps them as Hono middleware.
+
+## schema(opts?)
+
+Returns a standalone Zod schema derived from the model's fields. Can be used without Hono — in tests, background workers, or when composing schemas.
+
+\`\`\`typescript
+// Full schema
+const FullSchema = User.schema()
+
+// Narrowed with pick
+const NameEmailSchema = User.schema({ pick: (f) => [f.name, f.email] })
+
+// Partial update shape
+const PatchSchema = User.schema({ partial: true, omit: (f) => [f.passwordHash] })
+
+// Standalone parse — no Hono required
+const result = NameEmailSchema.safeParse(body)
+\`\`\`
+
+## validator(target, opts | preset, hook?)
+
+Returns a Hono middleware that validates the specified request target using the model's schema.
+
+\`\`\`typescript
+// Custom options
+app.post('/users', User.validator('json', { omit: (f) => [f.passwordHash] }), async (c) => {
+  const body = c.req.valid('json')
+  // body is typed — passwordHash excluded
+})
+
+// With a custom hook for error handling
+app.post(
+  '/users',
+  User.validator('json', 'create', (result, c) => {
+    if (!result.success) return c.json({ error: result.error.flatten() }, 400)
+  }),
+  handler,
+)
+\`\`\`
+
+## Presets
+
+Two presets are available as shorthand for common input shapes:
+
+**\`'create'\`** — applies \`inputSchema('create')\`: removes \`readOnly\` and \`serverOnly\` fields.
+
+\`\`\`typescript
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')
+  // id, createdAt (readOnly) and passwordHash (serverOnly) are excluded
+})
+\`\`\`
+
+**\`'update'\`** — applies \`inputSchema('update')\`: removes \`readOnly\` and \`serverOnly\` fields, then makes all remaining fields optional (\`partial: true\`).
+
+\`\`\`typescript
+app.patch('/users/:id', User.validator('json', 'update'), async (c) => {
+  const body = c.req.valid('json')
+  // all fields optional; readOnly and serverOnly excluded
+})
+\`\`\`
+
+## Custom Options
+
+When presets are not enough, pass explicit options:
+
+\`\`\`typescript
+interface SchemaOptions {
+  pick?:    string[] | ((f: FieldAccessor) => string[])
+  omit?:    string[] | ((f: FieldAccessor) => string[])
+  partial?: boolean
+}
+\`\`\`
+
+Operations are applied in order: pick → omit → partial.
+
+\`\`\`typescript
+// Accept only name and email, both optional
+const opts = { pick: (f) => [f.name, f.email], partial: true }
+app.patch('/profile', User.validator('json', opts), handler)
+\`\`\`
+
+## Field Accessor
+
+Both \`pick\` and \`omit\` accept a function \`(f) => [f.fieldName]\` where \`f\` maps every field name to itself as a string literal. This turns typos into compile-time type errors.
+
+\`\`\`typescript
+// Typo is a type error
+User.schema({ pick: (f) => [f.nme] })
+//                          ^^^^ Property 'nme' does not exist on type ...
+
+// Correct
+User.schema({ pick: (f) => [f.name] })
+\`\`\`
+
+## hook parameter
+
+The optional third argument to \`validator()\` is passed directly to \`@hono/zod-validator\`. Use it to customize the error response without replacing the entire middleware.
+
+\`\`\`typescript
+const hook = (result, c) => {
+  if (!result.success) return c.json({ errors: result.error.flatten().fieldErrors }, 422)
+}
+
+app.post('/users', User.validator('json', 'create', hook), handler)
+\`\`\`
+
+Using a hook is also the recommended way to prevent schema leak: the default \`@hono/zod-validator\` error includes the full Zod error tree, which may reveal field names that should be private.
+
+## inputSchema('create' | 'update', opts?)
+
+Returns a Zod schema with policies applied for the given input context.
+
+- \`'create'\`: removes \`serverOnly\` and \`readOnly\` fields.
+- \`'update'\`: removes \`serverOnly\` and \`readOnly\` fields, then applies \`partial: true\`.
+
+Additional \`opts\` are applied after policy filtering.
+
+\`\`\`typescript
+// Extend with a custom field
+const CreateBody = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+\`\`\`
+
+## outputSchema(opts?)
+
+Returns a Zod schema with policies applied for response output.
+
+- \`serverOnly\` fields are excluded.
+- \`writeOnly\` fields are excluded.
+- \`readOnly\` fields are **included** (they are safe to return).
+
+\`\`\`typescript
+// Parse an array of raw DB rows into safe response objects
+const rows = await app.db.select().from(User.table)
+const response = z.array(User.outputSchema()).parse(rows)
+\`\`\`
+
+## Policy application matrix
+
+The table below shows which policies are included or excluded by each method:
+
+| Method | serverOnly | writeOnly | readOnly |
+|---|---|---|---|
+| \`schema()\` | included | included | included |
+| \`inputSchema('create')\` | excluded | included | excluded |
+| \`inputSchema('update')\` | excluded | included | excluded |
+| \`outputSchema()\` | excluded | excluded | included |
+| \`validator('json', 'create')\` | excluded | included | excluded |
+| \`validator('json', 'update')\` | excluded | included | excluded |
+`
+
+export const contentJa = `\
+# Schema & Validator
+
+Nanoka は Zod スキーマを扱うための関連する 2 つの API を提供します: \`schema()\` / \`inputSchema()\` / \`outputSchema()\` はスタンドアロンの Zod オブジェクトを返し、\`validator()\` はそれらを Hono ミドルウェアとしてラップします。
+
+## schema(opts?)
+
+モデルのフィールドから派生したスタンドアロンの Zod スキーマを返します。Hono なしで使えます — テスト・バックグラウンドワーカー・スキーマ合成など。
+
+\`\`\`typescript
+// フルスキーマ
+const FullSchema = User.schema()
+
+// pick で絞り込み
+const NameEmailSchema = User.schema({ pick: (f) => [f.name, f.email] })
+
+// 部分的な update 形状
+const PatchSchema = User.schema({ partial: true, omit: (f) => [f.passwordHash] })
+
+// スタンドアロンでパース — Hono 不要
+const result = NameEmailSchema.safeParse(body)
+\`\`\`
+
+## validator(target, opts | preset, hook?)
+
+指定したリクエストターゲットをモデルのスキーマで検証する Hono ミドルウェアを返します。
+
+\`\`\`typescript
+// カスタムオプション
+app.post('/users', User.validator('json', { omit: (f) => [f.passwordHash] }), async (c) => {
+  const body = c.req.valid('json')
+  // body は型付き — passwordHash は除外済み
+})
+
+// エラーハンドリングのためのカスタムフック付き
+app.post(
+  '/users',
+  User.validator('json', 'create', (result, c) => {
+    if (!result.success) return c.json({ error: result.error.flatten() }, 400)
+  }),
+  handler,
+)
+\`\`\`
+
+## プリセット
+
+よく使う入力形状の短縮形として 2 つのプリセットが使えます:
+
+**\`'create'\`** — \`inputSchema('create')\` を適用: \`readOnly\` および \`serverOnly\` フィールドを除去します。
+
+\`\`\`typescript
+app.post('/users', User.validator('json', 'create'), async (c) => {
+  const body = c.req.valid('json')
+  // id、createdAt（readOnly）および passwordHash（serverOnly）は除外済み
+})
+\`\`\`
+
+**\`'update'\`** — \`inputSchema('update')\` を適用: \`readOnly\` および \`serverOnly\` フィールドを除去し、残りのすべてのフィールドをオプションにします（\`partial: true\`）。
+
+\`\`\`typescript
+app.patch('/users/:id', User.validator('json', 'update'), async (c) => {
+  const body = c.req.valid('json')
+  // 全フィールドがオプション; readOnly と serverOnly は除外済み
+})
+\`\`\`
+
+## カスタムオプション
+
+プリセットで足りない場合は、明示的なオプションを渡します:
+
+\`\`\`typescript
+interface SchemaOptions {
+  pick?:    string[] | ((f: FieldAccessor) => string[])
+  omit?:    string[] | ((f: FieldAccessor) => string[])
+  partial?: boolean
+}
+\`\`\`
+
+操作は pick → omit → partial の順で適用されます。
+
+\`\`\`typescript
+// name と email のみを受け付け、両方オプション
+const opts = { pick: (f) => [f.name, f.email], partial: true }
+app.patch('/profile', User.validator('json', opts), handler)
+\`\`\`
+
+## フィールドアクセサ
+
+\`pick\` と \`omit\` は両方、\`f\` が各フィールド名を文字列リテラルとして自身にマッピングする \`(f) => [f.fieldName]\` 関数を受け付けます。これにより、タイポがコンパイル時の型エラーになります。
+
+\`\`\`typescript
+// タイポは型エラー
+User.schema({ pick: (f) => [f.nme] })
+//                          ^^^^ Property 'nme' does not exist on type ...
+
+// 正しい
+User.schema({ pick: (f) => [f.name] })
+\`\`\`
+
+## hook パラメータ
+
+\`validator()\` のオプションの第 3 引数は \`@hono/zod-validator\` にそのまま渡されます。ミドルウェア全体を置き換えることなく、エラーレスポンスをカスタマイズするために使います。
+
+\`\`\`typescript
+const hook = (result, c) => {
+  if (!result.success) return c.json({ errors: result.error.flatten().fieldErrors }, 422)
+}
+
+app.post('/users', User.validator('json', 'create', hook), handler)
+\`\`\`
+
+フックの使用は、スキーマリーク防止にも推奨されます: デフォルトの \`@hono/zod-validator\` エラーには完全な Zod エラーツリーが含まれ、非公開にすべきフィールド名が漏れる可能性があります。
+
+## inputSchema('create' | 'update', opts?)
+
+指定した入力コンテキストにポリシーを適用した Zod スキーマを返します。
+
+- \`'create'\`: \`serverOnly\` および \`readOnly\` フィールドを除去します。
+- \`'update'\`: \`serverOnly\` および \`readOnly\` フィールドを除去した後、\`partial: true\` を適用します。
+
+追加の \`opts\` はポリシーフィルタリングの後に適用されます。
+
+\`\`\`typescript
+// カスタムフィールドで拡張
+const CreateBody = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+\`\`\`
+
+## outputSchema(opts?)
+
+レスポンス出力用にポリシーを適用した Zod スキーマを返します。
+
+- \`serverOnly\` フィールドは除外されます。
+- \`writeOnly\` フィールドは除外されます。
+- \`readOnly\` フィールドは**含まれます**（返しても安全です）。
+
+\`\`\`typescript
+// 生の DB 行の配列を安全なレスポンスオブジェクトにパース
+const rows = await app.db.select().from(User.table)
+const response = z.array(User.outputSchema()).parse(rows)
+\`\`\`
+
+## ポリシー適用マトリクス
+
+以下の表は、各メソッドで各ポリシーが含まれるか除外されるかを示します:
+
+| メソッド | serverOnly | writeOnly | readOnly |
+|---|---|---|---|
+| \`schema()\` | 含まれる | 含まれる | 含まれる |
+| \`inputSchema('create')\` | 除外 | 含まれる | 除外 |
+| \`inputSchema('update')\` | 除外 | 含まれる | 除外 |
+| \`outputSchema()\` | 除外 | 除外 | 含まれる |
+| \`validator('json', 'create')\` | 除外 | 含まれる | 除外 |
+| \`validator('json', 'update')\` | 除外 | 含まれる | 除外 |
+`

--- a/site/src/docs-registry.ts
+++ b/site/src/docs-registry.ts
@@ -1,3 +1,20 @@
+import { contentEn as adaptersEn, contentJa as adaptersJa } from './content/api/adapters'
+import { contentEn as crudEn, contentJa as crudJa } from './content/api/crud'
+import { contentEn as escapeHatchEn, contentJa as escapeHatchJa } from './content/api/escape-hatch'
+import {
+  contentEn as fieldPoliciesEn,
+  contentJa as fieldPoliciesJa,
+} from './content/api/field-policies'
+import { contentEn as fieldTypesEn, contentJa as fieldTypesJa } from './content/api/field-types'
+import { contentEn as openapiEn, contentJa as openapiJa } from './content/api/openapi'
+import {
+  contentEn as responseShapingEn,
+  contentJa as responseShapingJa,
+} from './content/api/response-shaping'
+import {
+  contentEn as schemaValidatorEn,
+  contentJa as schemaValidatorJa,
+} from './content/api/schema-validator'
 import { contentEn as conceptsEn, contentJa as conceptsJa } from './content/concepts'
 import {
   contentEn as gettingStartedEn,
@@ -32,6 +49,23 @@ const gettingStartedHtmlJa = renderMarkdown(gettingStartedJa)
 const conceptsHtml = renderMarkdown(conceptsEn)
 const conceptsHtmlJa = renderMarkdown(conceptsJa)
 
+const fieldTypesHtml = renderMarkdown(fieldTypesEn)
+const fieldTypesHtmlJa = renderMarkdown(fieldTypesJa)
+const fieldPoliciesHtml = renderMarkdown(fieldPoliciesEn)
+const fieldPoliciesHtmlJa = renderMarkdown(fieldPoliciesJa)
+const schemaValidatorHtml = renderMarkdown(schemaValidatorEn)
+const schemaValidatorHtmlJa = renderMarkdown(schemaValidatorJa)
+const crudHtml = renderMarkdown(crudEn)
+const crudHtmlJa = renderMarkdown(crudJa)
+const responseShapingHtml = renderMarkdown(responseShapingEn)
+const responseShapingHtmlJa = renderMarkdown(responseShapingJa)
+const openapiHtml = renderMarkdown(openapiEn)
+const openapiHtmlJa = renderMarkdown(openapiJa)
+const escapeHatchHtml = renderMarkdown(escapeHatchEn)
+const escapeHatchHtmlJa = renderMarkdown(escapeHatchJa)
+const adaptersHtml = renderMarkdown(adaptersEn)
+const adaptersHtmlJa = renderMarkdown(adaptersJa)
+
 // 15 pages total
 export const docPages: readonly DocPage[] = [
   {
@@ -64,49 +98,70 @@ export const docPages: readonly DocPage[] = [
     path: '/api/field-types',
     title: 'Field Types',
     section: 'api',
-    content: PLACEHOLDER,
+    description: 'All field types and modifiers available in Nanoka model definitions.',
+    content: fieldTypesHtml,
+    contentJa: fieldTypesHtmlJa,
   },
   {
     path: '/api/field-policies',
     title: 'Field Policies',
     section: 'api',
-    content: PLACEHOLDER,
+    description:
+      'How readOnly, writeOnly, and serverOnly policies control API input and output shapes.',
+    content: fieldPoliciesHtml,
+    contentJa: fieldPoliciesHtmlJa,
   },
   {
     path: '/api/schema-validator',
     title: 'Schema & Validator',
     section: 'api',
-    content: PLACEHOLDER,
+    description:
+      'schema(), validator(), inputSchema(), and outputSchema() — standalone Zod schemas and Hono middleware derived from your model.',
+    content: schemaValidatorHtml,
+    contentJa: schemaValidatorHtmlJa,
   },
   {
     path: '/api/crud',
     title: 'CRUD Methods',
     section: 'api',
-    content: PLACEHOLDER,
+    description:
+      'findMany, findAll, findOne, create, update, and delete — adapter-bound CRUD methods on Nanoka models.',
+    content: crudHtml,
+    contentJa: crudHtmlJa,
   },
   {
     path: '/api/response-shaping',
     title: 'Response Shaping',
     section: 'api',
-    content: PLACEHOLDER,
+    description:
+      'toResponse() and toResponseMany() — strip serverOnly and writeOnly fields before returning data to clients.',
+    content: responseShapingHtml,
+    contentJa: responseShapingHtmlJa,
   },
   {
     path: '/api/openapi',
     title: 'OpenAPI',
     section: 'api',
-    content: PLACEHOLDER,
+    description: 'Generate OpenAPI 3.1 specs and serve Swagger UI from your Nanoka application.',
+    content: openapiHtml,
+    contentJa: openapiHtmlJa,
   },
   {
     path: '/api/escape-hatch',
     title: 'Escape Hatch',
     section: 'api',
-    content: PLACEHOLDER,
+    description:
+      'app.db and app.batch() — direct Drizzle access for joins, aggregations, and advanced queries.',
+    content: escapeHatchHtml,
+    contentJa: escapeHatchHtmlJa,
   },
   {
     path: '/api/adapters',
     title: 'Adapters',
     section: 'api',
-    content: PLACEHOLDER,
+    description: 'd1Adapter for Cloudflare D1 and tursoAdapter for Turso/libSQL.',
+    content: adaptersHtml,
+    contentJa: adaptersHtmlJa,
   },
   {
     path: '/guides/migration',

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -7,7 +7,7 @@
   "assets": {
     "directory": "./public",
     "binding": "ASSETS"
-  },
+  }
   // Cloudflare Workers Builds: connect this repo on the Cloudflare dashboard.
   // Set root directory = repo root, build command = "pnpm install --frozen-lockfile",
   // deploy command = "npx wrangler versions upload --config site/wrangler.jsonc", branch = main.

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -10,9 +10,5 @@
   },
   // Cloudflare Workers Builds: connect this repo on the Cloudflare dashboard.
   // Set root directory = repo root, build command = "pnpm install --frozen-lockfile",
-  // deploy command = "pnpm -C site run deploy", branch = main.
-  "build": {
-    "command": "pnpm install --frozen-lockfile",
-    "cwd": ".."
-  }
+  // deploy command = "npx wrangler versions upload --config site/wrangler.jsonc", branch = main.
 }

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -10,7 +10,7 @@
   },
   // Cloudflare Workers Builds: connect this repo on the Cloudflare dashboard.
   // Set root directory = repo root, build command = "pnpm install --frozen-lockfile",
-  // deploy command = "pnpm -C site deploy", branch = main.
+  // deploy command = "pnpm -C site run deploy", branch = main.
   "build": {
     "command": "pnpm install --frozen-lockfile",
     "cwd": ".."


### PR DESCRIPTION
## Summary

- API Reference 全8ページのコンテンツを EN/JA 両言語で執筆
- `site/src/content/api/` 配下に新規作成（field-types / field-policies / schema-validator / crud / response-shaping / openapi / escape-hatch / adapters）
- `site/src/docs-registry.ts` の PLACEHOLDER を実コンテンツに差し替え
- `serverOnly` フィールドは `CreateInput` から除外されるため `User.create()` に渡せない点を正確に説明（`app.db` escape hatch を推奨）

## Test plan

- [ ] `pnpm -C site typecheck` — pass
- [ ] `pnpm biome check site/src/content/api/ site/src/docs-registry.ts` — no errors
- [ ] 8ページ × EN/JA 言語トグルで PLACEHOLDER が表示されないことを目視確認
- [ ] サイドバーの API Reference セクションから全ページに到達できることを確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)