### PR TITLE
feat: docs-site Guides / CLI Reference コンテンツ執筆 (#62)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -50,6 +50,7 @@
 - スタイリング・レスポンシブ対応（CSS-only ドロワー、タイポグラフィ、OGP メタタグ） — [#59](https://github.com/nanokajs/nanoka/issues/59)
 - コンテンツ執筆（Introduction / Getting Started / Core Concepts）+ 言語トグル機構（EN/JA） — [#60](https://github.com/nanokajs/nanoka/issues/60)
 - API Reference コンテンツ執筆（Field Types / Field Policies / Schema & Validator / CRUD Methods / Response Shaping / OpenAPI / Escape Hatch / Adapters） — [#61](https://github.com/nanokajs/nanoka/issues/61)
+- Guides / CLI Reference コンテンツ執筆（Migration Workflow / Error Handling / Using with Turso / CLI Reference） — [#62](https://github.com/nanokajs/nanoka/issues/62)
 
 ## 未実装として残す（将来候補）
 

--- a/site/src/content/cli.ts
+++ b/site/src/content/cli.ts
@@ -1,0 +1,261 @@
+export const contentEn = `\
+# CLI Reference
+
+## nanoka generate
+
+Generates a Drizzle schema file from your Nanoka model definitions and optionally runs the full migration pipeline.
+
+\`\`\`bash
+npx nanoka generate [options]
+\`\`\`
+
+**Options:**
+
+| Option | Argument | Default | Description |
+|---|---|---|---|
+| \`--config\` | path | \`./nanoka.config.ts\` | Path to nanoka.config.ts |
+| \`--output\` | path | (from config) | Override output file path |
+| \`--no-migrate\` | — | — | Generate schema only, skip migration steps |
+| \`--apply\` | — | — | Run drizzle-kit generate + wrangler d1 migrations apply |
+| \`--db\` | name | (from config) | D1 database name |
+| \`--remote\` | — | — | Apply migrations to remote D1 (passes --remote to wrangler) |
+| \`--package-manager\` | pm | \`npx\` | Package manager: npx / pnpm / npm / yarn / bun |
+
+### Examples
+
+\`\`\`bash
+# Generate Drizzle schema and run drizzle-kit generate
+npx nanoka generate
+
+# Use a custom config file path
+npx nanoka generate --config ./custom/nanoka.config.ts
+
+# Generate schema only, skip drizzle-kit and wrangler
+npx nanoka generate --no-migrate
+
+# Full pipeline: generate schema, run drizzle-kit, apply to local D1
+npx nanoka generate --apply --db my-database
+
+# Full pipeline with remote deploy using pnpm
+npx nanoka generate --apply --db my-database --remote --package-manager pnpm
+\`\`\`
+
+## nanoka.config.ts
+
+The config file is read by \`nanoka generate\` to discover models and configure the migration pipeline.
+
+**Options:**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| \`output\` | string | \`./drizzle/schema.ts\` | Drizzle schema output file path |
+| \`models\` | Model[] | required | Array of Nanoka model definitions |
+| \`migrate.drizzleConfig\` | string | \`./drizzle.config.ts\` | Path to drizzle.config.ts |
+| \`migrate.database\` | string | — | D1 database name for wrangler |
+| \`migrate.packageManager\` | string | \`npx\` | Package manager for CLI commands |
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { User } from './src/models/user'
+import { Post } from './src/models/post'
+
+export default defineConfig({
+  output: './drizzle/schema.ts',
+  models: [User, Post],
+  migrate: {
+    drizzleConfig: './drizzle.config.ts',
+    database: 'my-database',
+    packageManager: 'pnpm',
+  },
+})
+\`\`\`
+
+## create-nanoka-app
+
+Scaffold a new Nanoka project with a default template.
+
+\`\`\`bash
+pnpm create nanoka-app <dir>
+npx create-nanoka-app <dir>
+\`\`\`
+
+**Options:**
+
+| Option | Argument | Description |
+|---|---|---|
+| \`--template\` | \`default\` | Use the default template |
+| \`--force\` | — | Overwrite existing directory |
+| \`--help\` | — | Show help |
+| \`--version\` | — | Show version |
+
+### Generated Files
+
+| Path | Description |
+|---|---|
+| \`package.json\` | Project dependencies and scripts |
+| \`wrangler.jsonc\` | Wrangler configuration with D1 binding |
+| \`tsconfig.json\` | TypeScript configuration |
+| \`drizzle.config.ts\` | Drizzle-kit configuration |
+| \`nanoka.config.ts\` | Nanoka model and migration configuration |
+| \`.gitignore\` | Standard gitignore for Node/Wrangler projects |
+| \`README.md\` | Quickstart instructions |
+| \`src/index.ts\` | Worker entry point with example routes |
+| \`src/models/posts.ts\` | Post model as a starting example |
+
+The \`src/models/posts.ts\` file defines a \`Post\` model with \`id\`, \`title\`, \`body\`, \`published\`, and \`createdAt\` fields. Edit or replace it with your own models.
+
+### Next Steps
+
+After scaffolding, run the following commands to get your project running:
+
+\`\`\`bash
+# 1. Install dependencies
+pnpm install
+
+# 2. Generate the Drizzle schema from model definitions
+pnpm exec nanoka generate
+
+# 3. Generate SQL migration files
+pnpm exec drizzle-kit generate
+
+# 4. Create the D1 database if needed
+npx wrangler d1 create my-database
+
+# 5. Apply migrations to local D1
+pnpm exec wrangler d1 migrations apply my-database --local
+
+# 6. Start the local dev server
+pnpm dev
+\`\`\`
+`
+
+export const contentJa = `\
+# CLI Reference
+
+## nanoka generate
+
+Nanoka モデル定義から Drizzle スキーマファイルを生成し、オプションでマイグレーションパイプライン全体を実行します。
+
+\`\`\`bash
+npx nanoka generate [options]
+\`\`\`
+
+**オプション:**
+
+| オプション | 引数 | デフォルト | 説明 |
+|---|---|---|---|
+| \`--config\` | path | \`./nanoka.config.ts\` | nanoka.config.ts へのパス |
+| \`--output\` | path | （config から）| 出力ファイルパスを上書き |
+| \`--no-migrate\` | — | — | スキーマ生成のみ、マイグレーション手順をスキップ |
+| \`--apply\` | — | — | drizzle-kit generate + wrangler d1 migrations apply を実行 |
+| \`--db\` | name | （config から）| D1 データベース名 |
+| \`--remote\` | — | — | リモート D1 にマイグレーションを適用（wrangler に --remote を渡す）|
+| \`--package-manager\` | pm | \`npx\` | パッケージマネージャ: npx / pnpm / npm / yarn / bun |
+
+### 使用例
+
+\`\`\`bash
+# Drizzle スキーマを生成して drizzle-kit generate を実行
+npx nanoka generate
+
+# カスタム設定ファイルパスを使用
+npx nanoka generate --config ./custom/nanoka.config.ts
+
+# スキーマ生成のみ、drizzle-kit と wrangler をスキップ
+npx nanoka generate --no-migrate
+
+# フルパイプライン: スキーマ生成・drizzle-kit 実行・ローカル D1 への適用
+npx nanoka generate --apply --db my-database
+
+# pnpm を使ってリモートデプロイするフルパイプライン
+npx nanoka generate --apply --db my-database --remote --package-manager pnpm
+\`\`\`
+
+## nanoka.config.ts
+
+設定ファイルは \`nanoka generate\` がモデルを検出してマイグレーションパイプラインを設定するために読み込まれます。
+
+**オプション:**
+
+| オプション | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| \`output\` | string | \`./drizzle/schema.ts\` | Drizzle スキーマの出力ファイルパス |
+| \`models\` | Model[] | 必須 | Nanoka モデル定義の配列 |
+| \`migrate.drizzleConfig\` | string | \`./drizzle.config.ts\` | drizzle.config.ts へのパス |
+| \`migrate.database\` | string | — | wrangler 用 D1 データベース名 |
+| \`migrate.packageManager\` | string | \`npx\` | CLI コマンド用パッケージマネージャ |
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { User } from './src/models/user'
+import { Post } from './src/models/post'
+
+export default defineConfig({
+  output: './drizzle/schema.ts',
+  models: [User, Post],
+  migrate: {
+    drizzleConfig: './drizzle.config.ts',
+    database: 'my-database',
+    packageManager: 'pnpm',
+  },
+})
+\`\`\`
+
+## create-nanoka-app
+
+デフォルトテンプレートで新しい Nanoka プロジェクトをスキャフォールドします。
+
+\`\`\`bash
+pnpm create nanoka-app <dir>
+npx create-nanoka-app <dir>
+\`\`\`
+
+**オプション:**
+
+| オプション | 引数 | 説明 |
+|---|---|---|
+| \`--template\` | \`default\` | デフォルトテンプレートを使用 |
+| \`--force\` | — | 既存ディレクトリを上書き |
+| \`--help\` | — | ヘルプを表示 |
+| \`--version\` | — | バージョンを表示 |
+
+### 生成されるファイル
+
+| パス | 説明 |
+|---|---|
+| \`package.json\` | プロジェクトの依存パッケージとスクリプト |
+| \`wrangler.jsonc\` | D1 バインディングを含む Wrangler 設定 |
+| \`tsconfig.json\` | TypeScript 設定 |
+| \`drizzle.config.ts\` | Drizzle-kit 設定 |
+| \`nanoka.config.ts\` | Nanoka モデルとマイグレーション設定 |
+| \`.gitignore\` | Node/Wrangler プロジェクト用の標準 gitignore |
+| \`README.md\` | クイックスタート手順 |
+| \`src/index.ts\` | サンプルルート付きの Worker エントリポイント |
+| \`src/models/posts.ts\` | 開始例としての Post モデル |
+
+\`src/models/posts.ts\` には \`id\`・\`title\`・\`body\`・\`published\`・\`createdAt\` フィールドを持つ \`Post\` モデルが定義されています。自分のモデルに編集または置き換えてください。
+
+### 次のステップ
+
+スキャフォールド後、以下のコマンドでプロジェクトを起動します:
+
+\`\`\`bash
+# 1. 依存パッケージをインストール
+pnpm install
+
+# 2. モデル定義から Drizzle スキーマを生成
+pnpm exec nanoka generate
+
+# 3. SQL マイグレーションファイルを生成
+pnpm exec drizzle-kit generate
+
+# 4. 必要に応じて D1 データベースを作成
+npx wrangler d1 create my-database
+
+# 5. ローカル D1 にマイグレーションを適用
+pnpm exec wrangler d1 migrations apply my-database --local
+
+# 6. ローカル開発サーバを起動
+pnpm dev
+\`\`\`
+`

--- a/site/src/content/guides/error-handling.ts
+++ b/site/src/content/guides/error-handling.ts
@@ -1,0 +1,315 @@
+export const contentEn = `\
+# Error Handling
+
+Nanoka's router is Hono-compatible. Error handling follows standard Hono patterns using \`HTTPException\` and \`app.onError\`.
+
+## Throwing HTTPException
+
+Import \`HTTPException\` from \`hono/http-exception\` and throw it anywhere in a route handler:
+
+\`\`\`typescript
+import { HTTPException } from 'hono/http-exception'
+
+// 404 — resource not found
+if (!user) throw new HTTPException(404, { message: 'User not found' })
+
+// 400 — bad request
+throw new HTTPException(400, { message: 'Invalid input' })
+
+// 401 — authentication required
+throw new HTTPException(401, { message: 'Unauthorized' })
+
+// 403 — forbidden
+throw new HTTPException(403, { message: 'Forbidden' })
+\`\`\`
+
+## Global Error Handler
+
+Register \`app.onError\` to catch all unhandled errors:
+
+\`\`\`typescript
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
+  console.error(err)
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+Calling \`err.getResponse()\` returns the response with the status code and message you passed to \`HTTPException\`. Errors that are not \`HTTPException\` instances become 500 responses.
+
+## Hiding Stack Traces in 5xx
+
+Never return stack traces in production responses. Internal file paths, variable names, and SQL queries can be leaked in a stack trace, giving attackers useful information about your application internals.
+
+If you want richer error details during local development, gate them behind an environment variable:
+
+\`\`\`typescript
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
+  if (c.env.DEBUG) {
+    return c.json({ error: err.message, stack: err.stack }, 500)
+  }
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+Only set \`DEBUG=1\` in local development via \`.dev.vars\`. Never enable it in production.
+
+## Zod Validation Errors — Default Behavior
+
+By default, the Hono validator middleware returns a 400 response that includes the full Zod issues object when validation fails. This exposes your internal schema structure (field names, validation rules) to API clients.
+
+## Option 1 — Validator Hook
+
+Use the hook parameter on \`User.validator\` to customize the error response per route:
+
+\`\`\`typescript
+app.post('/users', User.validator('json', 'create', (result, c) => {
+  if (!result.success) {
+    throw new HTTPException(400, { message: 'Invalid input' })
+  }
+}), async (c) => {
+  const body = c.req.valid('json')
+  // ...
+})
+\`\`\`
+
+The hook receives the Zod parse result and the Hono context. Throwing \`HTTPException\` here produces a clean 400 with only your message.
+
+## Option 2 — onError ZodError Catch
+
+Catch \`ZodError\` globally in \`app.onError\`:
+
+\`\`\`typescript
+import { ZodError } from 'zod'
+
+app.onError((err, c) => {
+  if (err instanceof HTTPException) return err.getResponse()
+  if (err instanceof ZodError) {
+    return c.json({ error: 'Invalid input' }, 400)
+  }
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+This applies to all \`ZodError\` throws — including manual \`schema.parse()\` calls inside handlers — not just validator middleware errors.
+
+## Password Field Pattern
+
+When a route needs to accept a plain-text password, extend \`inputSchema\` with the extra field, hash it server-side, and store only the hash:
+
+\`\`\`typescript
+import { z } from 'zod'
+
+const createUserSchema = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+
+app.post('/users', async (c) => {
+  const body = await c.req.json()
+  const data = createUserSchema.parse(body)
+  const { password, ...rest } = data
+  const passwordHash = await hashPassword(password)
+  const user = await User.create(adapter, { ...rest, passwordHash })
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+The \`passwordHash\` field is \`serverOnly()\` so it never appears in responses, even if you forget to strip it manually.
+
+## D1 / Drizzle Errors
+
+Catch constraint violations and return safe error messages without exposing internal error details:
+
+\`\`\`typescript
+try {
+  const user = await User.create(adapter, data)
+  return c.json(User.toResponse(user), 201)
+} catch (err) {
+  if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+    throw new HTTPException(409, { message: 'Email already in use' })
+  }
+  throw err
+}
+\`\`\`
+
+The internal \`UNIQUE constraint failed\` message is never forwarded to the client. Re-throwing the error for non-constraint cases lets \`app.onError\` handle them as 500s.
+
+## Status Code Patterns
+
+\`\`\`typescript
+// 201 Created
+return c.json(body, 201)
+
+// 204 No Content
+return new Response(null, { status: 204 })
+
+// 404 Not Found
+throw new HTTPException(404, { message: 'Not found' })
+
+// 409 Conflict
+throw new HTTPException(409, { message: 'Email already in use' })
+\`\`\`
+`
+
+export const contentJa = `\
+# Error Handling
+
+Nanoka のルーターは Hono 互換です。エラーハンドリングは \`HTTPException\` と \`app.onError\` を使った標準的な Hono パターンに従います。
+
+## HTTPException をスローする
+
+\`hono/http-exception\` から \`HTTPException\` をインポートし、ルートハンドラの任意の場所でスローします:
+
+\`\`\`typescript
+import { HTTPException } from 'hono/http-exception'
+
+// 404 — リソースが見つからない
+if (!user) throw new HTTPException(404, { message: 'User not found' })
+
+// 400 — 不正なリクエスト
+throw new HTTPException(400, { message: 'Invalid input' })
+
+// 401 — 認証が必要
+throw new HTTPException(401, { message: 'Unauthorized' })
+
+// 403 — アクセス禁止
+throw new HTTPException(403, { message: 'Forbidden' })
+\`\`\`
+
+## グローバルエラーハンドラ
+
+すべての未処理エラーをキャッチするために \`app.onError\` を登録します:
+
+\`\`\`typescript
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
+  console.error(err)
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+\`err.getResponse()\` を呼ぶと、\`HTTPException\` に渡したステータスコードとメッセージでレスポンスを返します。\`HTTPException\` インスタンスでないエラーは 500 レスポンスになります。
+
+## 5xx でスタックトレースを隠す
+
+本番環境のレスポンスにスタックトレースを含めてはいけません。スタックトレースには内部のファイルパス・変数名・SQL クエリが漏れる可能性があり、攻撃者にアプリケーション内部の有用な情報を与えます。
+
+ローカル開発中により詳細なエラー情報が必要な場合は、環境変数でゲートします:
+
+\`\`\`typescript
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse()
+  }
+  if (c.env.DEBUG) {
+    return c.json({ error: err.message, stack: err.stack }, 500)
+  }
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+\`DEBUG=1\` は \`.dev.vars\` 経由でローカル開発時のみ設定してください。本番環境では絶対に有効にしないでください。
+
+## Zod バリデーションエラー — デフォルトの挙動
+
+デフォルトでは、Hono バリデータミドルウェアはバリデーション失敗時に Zod の issues オブジェクト全体を含む 400 レスポンスを返します。これにより API クライアントに内部のスキーマ構造（フィールド名、バリデーションルール）が露出します。
+
+## Option 1 — バリデータフック
+
+\`User.validator\` の hook パラメータを使ってルートごとにエラーレスポンスをカスタマイズします:
+
+\`\`\`typescript
+app.post('/users', User.validator('json', 'create', (result, c) => {
+  if (!result.success) {
+    throw new HTTPException(400, { message: 'Invalid input' })
+  }
+}), async (c) => {
+  const body = c.req.valid('json')
+  // ...
+})
+\`\`\`
+
+フックは Zod のパース結果と Hono コンテキストを受け取ります。ここで \`HTTPException\` をスローすると、メッセージだけを含むきれいな 400 が返ります。
+
+## Option 2 — onError で ZodError をキャッチ
+
+\`app.onError\` でグローバルに \`ZodError\` をキャッチします:
+
+\`\`\`typescript
+import { ZodError } from 'zod'
+
+app.onError((err, c) => {
+  if (err instanceof HTTPException) return err.getResponse()
+  if (err instanceof ZodError) {
+    return c.json({ error: 'Invalid input' }, 400)
+  }
+  return c.json({ error: 'Internal Server Error' }, 500)
+})
+\`\`\`
+
+これはバリデータミドルウェアのエラーだけでなく、ハンドラ内での手動 \`schema.parse()\` 呼び出しも含む、すべての \`ZodError\` スローに適用されます。
+
+## パスワードフィールドのパターン
+
+ルートで平文パスワードを受け取る必要がある場合は、\`inputSchema\` を拡張して追加フィールドを加え、サーバーサイドでハッシュ化してハッシュのみを保存します:
+
+\`\`\`typescript
+import { z } from 'zod'
+
+const createUserSchema = User.inputSchema('create').extend({
+  password: z.string().min(8),
+})
+
+app.post('/users', async (c) => {
+  const body = await c.req.json()
+  const data = createUserSchema.parse(body)
+  const { password, ...rest } = data
+  const passwordHash = await hashPassword(password)
+  const user = await User.create(adapter, { ...rest, passwordHash })
+  return c.json(User.toResponse(user), 201)
+})
+\`\`\`
+
+\`passwordHash\` フィールドは \`serverOnly()\` なので、手動で除外し忘れてもレスポンスに含まれることはありません。
+
+## D1 / Drizzle エラー
+
+制約違反をキャッチし、内部エラーの詳細を露出させずに安全なエラーメッセージを返します:
+
+\`\`\`typescript
+try {
+  const user = await User.create(adapter, data)
+  return c.json(User.toResponse(user), 201)
+} catch (err) {
+  if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+    throw new HTTPException(409, { message: 'Email already in use' })
+  }
+  throw err
+}
+\`\`\`
+
+内部の \`UNIQUE constraint failed\` メッセージはクライアントに転送されません。制約違反以外のエラーを再スローすることで、\`app.onError\` が 500 として処理します。
+
+## ステータスコードパターン
+
+\`\`\`typescript
+// 201 Created
+return c.json(body, 201)
+
+// 204 No Content
+return new Response(null, { status: 204 })
+
+// 404 Not Found
+throw new HTTPException(404, { message: 'Not found' })
+
+// 409 Conflict
+throw new HTTPException(409, { message: 'Email already in use' })
+\`\`\`
+`

--- a/site/src/content/guides/migration.ts
+++ b/site/src/content/guides/migration.ts
@@ -1,0 +1,279 @@
+export const contentEn = `\
+# Migration Workflow
+
+Nanoka uses a three-stage pipeline to get your model definitions into a running database. This page explains each stage and the options available at each step.
+
+## Pipeline Overview
+
+\`\`\`
+Model Definition → nanoka generate → Drizzle Schema → drizzle-kit generate → SQL Migrations → wrangler d1 migrations apply → D1
+\`\`\`
+
+## nanoka.config.ts
+
+The config file tells \`nanoka generate\` which models to process and where to write output. Use \`defineConfig\` from \`@nanokajs/core/config\`:
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { User } from './src/models/user'
+import { Post } from './src/models/post'
+
+export default defineConfig({
+  output: './drizzle/schema.ts',
+  models: [User, Post],
+  migrate: {
+    drizzleConfig: './drizzle.config.ts',
+    database: 'my-database',
+    packageManager: 'pnpm',
+  },
+})
+\`\`\`
+
+**Fields:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| \`output\` | string | \`./drizzle/schema.ts\` | Output file path for generated Drizzle schema |
+| \`models\` | Model[] | required | Array of Nanoka model definitions |
+| \`migrate.drizzleConfig\` | string | \`./drizzle.config.ts\` | Path to drizzle.config.ts |
+| \`migrate.database\` | string | — | D1 database name for wrangler |
+| \`migrate.packageManager\` | string | \`npx\` | Package manager for CLI commands |
+
+## drizzle.config.ts
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'sqlite',
+  driver: 'd1-http',
+  schema: './drizzle/schema.ts',
+  out: './drizzle/migrations',
+})
+\`\`\`
+
+## Option A — Unified Pipeline
+
+Run the full pipeline in one command:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database
+# Or with remote deploy:
+npx nanoka generate --apply --db my-database --remote
+\`\`\`
+
+## Option B — Step by Step
+
+\`\`\`bash
+# 1. Generate Drizzle schema
+npx nanoka generate
+
+# 2. Generate SQL migrations
+npx drizzle-kit generate
+
+# 3. Apply to local D1
+npx wrangler d1 migrations apply my-database --local
+\`\`\`
+
+## Option C — Schema Generation Only
+
+\`\`\`bash
+npx nanoka generate --no-migrate
+\`\`\`
+
+This generates the Drizzle schema file but skips all migration steps. Useful for CI diffing and codegen-only workflows.
+
+## Remote Deploys
+
+Pass \`--remote\` to apply migrations to the production D1 database instead of the local instance:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database --remote
+\`\`\`
+
+The \`--remote\` flag is passed directly to \`wrangler d1 migrations apply\`. To inspect the current migration state:
+
+\`\`\`bash
+npx wrangler d1 migrations list my-database --remote
+\`\`\`
+
+## Adding a New Model
+
+1. Create a model file (e.g., \`src/models/post.ts\`)
+2. Add it to the \`models\` array in \`nanoka.config.ts\`
+3. Run the pipeline:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database
+\`\`\`
+
+## Modifying a Field
+
+Nanoka regenerates the Drizzle schema from your updated model definition. \`drizzle-kit generate\` then diffs the schema against the previous migration and generates the SQL for the change.
+
+When \`drizzle-kit\` detects a rename or drop, it prompts interactively for confirmation. Nanoka does not intercept or automate this step — the diff and SQL generation logic lives entirely in \`drizzle-kit\`.
+
+## Generated Drizzle Schema Example
+
+Given a User model with typical fields, \`nanoka generate\` writes:
+
+\`\`\`typescript
+import { integer, text, sqliteTable } from 'drizzle-orm/sqlite-core'
+
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey().notNull(),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull(),
+  passwordHash: text('passwordHash').notNull(),
+  createdAt: integer('createdAt', { mode: 'timestamp_ms' }).notNull(),
+})
+\`\`\`
+
+This file is a standard Drizzle schema — you can inspect it, commit it, and use it directly with any Drizzle query.
+
+## Note on t.json() and Codegen
+
+- \`t.json()\` generates: \`text('data', { mode: 'json' }).$type<unknown>()\`
+- After generation, manually update \`$type<unknown>()\` to \`$type<MyShape>()\` to get proper TypeScript types on that column.
+- Function defaults (e.g., \`t.timestamp().default(() => new Date())\`) are dropped during codegen with a warning. Add \`$defaultFn(() => new Date())\` manually to the generated schema if you need a runtime default on that column.
+`
+
+export const contentJa = `\
+# Migration Workflow
+
+Nanoka はモデル定義をデータベースに反映するために 3 段階のパイプラインを使用します。このページでは各段階と利用できるオプションを説明します。
+
+## パイプライン概要
+
+\`\`\`
+モデル定義 → nanoka generate → Drizzle スキーマ → drizzle-kit generate → SQL マイグレーション → wrangler d1 migrations apply → D1
+\`\`\`
+
+## nanoka.config.ts
+
+設定ファイルは \`nanoka generate\` に処理するモデルと出力先を伝えます。\`@nanokajs/core/config\` の \`defineConfig\` を使用します:
+
+\`\`\`typescript
+import { defineConfig } from '@nanokajs/core/config'
+import { User } from './src/models/user'
+import { Post } from './src/models/post'
+
+export default defineConfig({
+  output: './drizzle/schema.ts',
+  models: [User, Post],
+  migrate: {
+    drizzleConfig: './drizzle.config.ts',
+    database: 'my-database',
+    packageManager: 'pnpm',
+  },
+})
+\`\`\`
+
+**フィールド:**
+
+| フィールド | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| \`output\` | string | \`./drizzle/schema.ts\` | 生成された Drizzle スキーマの出力ファイルパス |
+| \`models\` | Model[] | 必須 | Nanoka モデル定義の配列 |
+| \`migrate.drizzleConfig\` | string | \`./drizzle.config.ts\` | drizzle.config.ts へのパス |
+| \`migrate.database\` | string | — | wrangler 用 D1 データベース名 |
+| \`migrate.packageManager\` | string | \`npx\` | CLI コマンド用パッケージマネージャ |
+
+## drizzle.config.ts
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'sqlite',
+  driver: 'd1-http',
+  schema: './drizzle/schema.ts',
+  out: './drizzle/migrations',
+})
+\`\`\`
+
+## Option A — 統合パイプライン
+
+1 コマンドでパイプライン全体を実行します:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database
+# またはリモートデプロイ:
+npx nanoka generate --apply --db my-database --remote
+\`\`\`
+
+## Option B — ステップ別実行
+
+\`\`\`bash
+# 1. Drizzle スキーマを生成
+npx nanoka generate
+
+# 2. SQL マイグレーションを生成
+npx drizzle-kit generate
+
+# 3. ローカル D1 に適用
+npx wrangler d1 migrations apply my-database --local
+\`\`\`
+
+## Option C — スキーマ生成のみ
+
+\`\`\`bash
+npx nanoka generate --no-migrate
+\`\`\`
+
+Drizzle スキーマファイルを生成しますが、マイグレーション手順をすべてスキップします。CI での差分確認やコード生成のみのワークフローに便利です。
+
+## リモートデプロイ
+
+\`--remote\` を指定すると、ローカルインスタンスではなく本番 D1 データベースにマイグレーションを適用します:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database --remote
+\`\`\`
+
+\`--remote\` フラグは \`wrangler d1 migrations apply\` に直接渡されます。現在のマイグレーション状態を確認するには:
+
+\`\`\`bash
+npx wrangler d1 migrations list my-database --remote
+\`\`\`
+
+## 新しいモデルを追加する
+
+1. モデルファイルを作成（例: \`src/models/post.ts\`）
+2. \`nanoka.config.ts\` の \`models\` 配列に追加
+3. パイプラインを実行:
+
+\`\`\`bash
+npx nanoka generate --apply --db my-database
+\`\`\`
+
+## フィールドを変更する
+
+Nanoka は更新されたモデル定義から Drizzle スキーマを再生成します。次に \`drizzle-kit generate\` がスキーマと前回のマイグレーションを比較して変更の SQL を生成します。
+
+\`drizzle-kit\` がリネームや削除を検出すると、確認のためインタラクティブにプロンプトを表示します。Nanoka はこのステップを横取りしたり自動化したりしません — 差分と SQL 生成ロジックはすべて \`drizzle-kit\` に委ねられています。
+
+## 生成された Drizzle スキーマの例
+
+典型的なフィールドを持つ User モデルに対して \`nanoka generate\` が書き出す内容:
+
+\`\`\`typescript
+import { integer, text, sqliteTable } from 'drizzle-orm/sqlite-core'
+
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey().notNull(),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull(),
+  passwordHash: text('passwordHash').notNull(),
+  createdAt: integer('createdAt', { mode: 'timestamp_ms' }).notNull(),
+})
+\`\`\`
+
+このファイルは標準の Drizzle スキーマです — 確認してコミットし、任意の Drizzle クエリで直接使用できます。
+
+## t.json() とコード生成についての注意
+
+- \`t.json()\` は次を生成します: \`text('data', { mode: 'json' }).$type<unknown>()\`
+- 生成後、そのカラムで適切な TypeScript 型を得るには、\`$type<unknown>()\` を \`$type<MyShape>()\` に手動で更新してください。
+- 関数デフォルト（例: \`t.timestamp().default(() => new Date())\`）はコード生成時に警告付きでドロップされます。そのカラムでランタイムデフォルトが必要な場合は、生成されたスキーマに \`$defaultFn(() => new Date())\` を手動で追加してください。
+`

--- a/site/src/content/guides/turso.ts
+++ b/site/src/content/guides/turso.ts
@@ -1,0 +1,275 @@
+export const contentEn = `\
+# Using with Turso
+
+This page covers the practical steps for using Nanoka with Turso/libSQL in a Cloudflare Worker. For the full adapter API reference, see [/api/adapters](/api/adapters).
+
+## Install
+
+\`\`\`bash
+pnpm add @libsql/client
+\`\`\`
+
+## Setup
+
+Create the Turso client inside the \`fetch\` handler so each request gets a fresh connection, then pass it to \`tursoAdapter\`:
+
+\`\`\`typescript
+import { nanoka } from '@nanokajs/core'
+import { tursoAdapter } from '@nanokajs/core/turso'
+import { createClient } from '@libsql/client'
+import { User } from './models/user'
+
+export interface Env {
+  TURSO_URL: string
+  TURSO_AUTH_TOKEN: string
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const client = createClient({
+      url: env.TURSO_URL,
+      authToken: env.TURSO_AUTH_TOKEN,
+    })
+    const adapter = tursoAdapter(client)
+    const app = nanoka(adapter)
+    app.model(User)
+    // routes...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+## Secrets
+
+Store credentials as Wrangler secrets, never in source code or \`wrangler.jsonc\`:
+
+\`\`\`bash
+wrangler secret put TURSO_URL
+wrangler secret put TURSO_AUTH_TOKEN
+\`\`\`
+
+For local development, add them to \`.dev.vars\` (keep this file in \`.gitignore\`):
+
+\`\`\`
+TURSO_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+## Local Development
+
+Use a local SQLite file during development to avoid needing a live Turso database:
+
+\`\`\`typescript
+const client = createClient({
+  url: 'file:local.db',
+})
+\`\`\`
+
+Or set \`TURSO_URL=file:local.db\` in \`.dev.vars\` and leave \`TURSO_AUTH_TOKEN\` empty. Apply migrations to the local file:
+
+\`\`\`bash
+npx drizzle-kit migrate
+\`\`\`
+
+## Migrations for Turso
+
+Update \`drizzle.config.ts\` to use the \`turso\` dialect:
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'turso',
+  schema: './drizzle/schema.ts',
+  out: './drizzle/migrations',
+  dbCredentials: {
+    url: process.env.TURSO_URL!,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  },
+})
+\`\`\`
+
+Apply migrations:
+
+\`\`\`bash
+npx drizzle-kit migrate
+\`\`\`
+
+## Switching from D1 to Turso
+
+The following changes are required when switching an existing D1-based app to Turso:
+
+**1. Add dependency:**
+\`\`\`bash
+pnpm add @libsql/client
+\`\`\`
+
+**2. Update import in worker:**
+\`\`\`typescript
+- import { d1Adapter } from '@nanokajs/core'
++ import { tursoAdapter } from '@nanokajs/core/turso'
++ import { createClient } from '@libsql/client'
+\`\`\`
+
+**3. Update env interface:**
+\`\`\`typescript
+- export interface Env {
+-   DB: D1Database
+- }
++ export interface Env {
++   TURSO_URL: string
++   TURSO_AUTH_TOKEN: string
++ }
+\`\`\`
+
+**4. Update adapter initialization:**
+\`\`\`typescript
+- const app = nanoka(d1Adapter(env.DB))
++ const client = createClient({ url: env.TURSO_URL, authToken: env.TURSO_AUTH_TOKEN })
++ const app = nanoka(tursoAdapter(client))
+\`\`\`
+
+**5. wrangler.jsonc:** Remove the \`d1_databases\` binding. The Turso credentials are managed as secrets and do not appear in \`wrangler.jsonc\`.
+
+**6. drizzle.config.ts:** Change \`dialect\` from \`'sqlite'\` to \`'turso'\` and add \`dbCredentials\`.
+
+**7. Migration command:** Replace \`wrangler d1 migrations apply\` with \`drizzle-kit migrate\`.
+`
+
+export const contentJa = `\
+# Using with Turso
+
+このページでは、Cloudflare Worker で Nanoka を Turso/libSQL と組み合わせて使う実践的な手順を説明します。アダプター API リファレンスの詳細については [/api/adapters](/api/adapters) を参照してください。
+
+## インストール
+
+\`\`\`bash
+pnpm add @libsql/client
+\`\`\`
+
+## セットアップ
+
+各リクエストで新しい接続を得るために \`fetch\` ハンドラ内で Turso クライアントを作成し、\`tursoAdapter\` に渡します:
+
+\`\`\`typescript
+import { nanoka } from '@nanokajs/core'
+import { tursoAdapter } from '@nanokajs/core/turso'
+import { createClient } from '@libsql/client'
+import { User } from './models/user'
+
+export interface Env {
+  TURSO_URL: string
+  TURSO_AUTH_TOKEN: string
+}
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const client = createClient({
+      url: env.TURSO_URL,
+      authToken: env.TURSO_AUTH_TOKEN,
+    })
+    const adapter = tursoAdapter(client)
+    const app = nanoka(adapter)
+    app.model(User)
+    // routes...
+    return app.fetch(req, env, ctx)
+  },
+}
+\`\`\`
+
+## シークレット
+
+認証情報はソースコードや \`wrangler.jsonc\` ではなく、Wrangler のシークレットとして保存します:
+
+\`\`\`bash
+wrangler secret put TURSO_URL
+wrangler secret put TURSO_AUTH_TOKEN
+\`\`\`
+
+ローカル開発用には \`.dev.vars\` に追加します（このファイルは \`.gitignore\` に含めること）:
+
+\`\`\`
+TURSO_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=your-token
+\`\`\`
+
+## ローカル開発
+
+開発中はライブの Turso データベースを必要としないよう、ローカル SQLite ファイルを使用します:
+
+\`\`\`typescript
+const client = createClient({
+  url: 'file:local.db',
+})
+\`\`\`
+
+または \`.dev.vars\` に \`TURSO_URL=file:local.db\` を設定し、\`TURSO_AUTH_TOKEN\` を空のままにします。ローカルファイルにマイグレーションを適用するには:
+
+\`\`\`bash
+npx drizzle-kit migrate
+\`\`\`
+
+## Turso 用マイグレーション
+
+\`drizzle.config.ts\` を \`turso\` ダイアレクトを使うように更新します:
+
+\`\`\`typescript
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'turso',
+  schema: './drizzle/schema.ts',
+  out: './drizzle/migrations',
+  dbCredentials: {
+    url: process.env.TURSO_URL!,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  },
+})
+\`\`\`
+
+マイグレーションを適用:
+
+\`\`\`bash
+npx drizzle-kit migrate
+\`\`\`
+
+## D1 から Turso への切り替え
+
+既存の D1 ベースのアプリを Turso に切り替える際に必要な変更:
+
+**1. 依存パッケージを追加:**
+\`\`\`bash
+pnpm add @libsql/client
+\`\`\`
+
+**2. ワーカーのインポートを更新:**
+\`\`\`typescript
+- import { d1Adapter } from '@nanokajs/core'
++ import { tursoAdapter } from '@nanokajs/core/turso'
++ import { createClient } from '@libsql/client'
+\`\`\`
+
+**3. env インターフェースを更新:**
+\`\`\`typescript
+- export interface Env {
+-   DB: D1Database
+- }
++ export interface Env {
++   TURSO_URL: string
++   TURSO_AUTH_TOKEN: string
++ }
+\`\`\`
+
+**4. アダプター初期化を更新:**
+\`\`\`typescript
+- const app = nanoka(d1Adapter(env.DB))
++ const client = createClient({ url: env.TURSO_URL, authToken: env.TURSO_AUTH_TOKEN })
++ const app = nanoka(tursoAdapter(client))
+\`\`\`
+
+**5. wrangler.jsonc:** \`d1_databases\` バインディングを削除します。Turso の認証情報はシークレットとして管理され、\`wrangler.jsonc\` には含まれません。
+
+**6. drizzle.config.ts:** \`dialect\` を \`'sqlite'\` から \`'turso'\` に変更し、\`dbCredentials\` を追加します。
+
+**7. マイグレーションコマンド:** \`wrangler d1 migrations apply\` を \`drizzle-kit migrate\` に置き換えます。
+`

--- a/site/src/docs-registry.ts
+++ b/site/src/docs-registry.ts
@@ -15,11 +15,18 @@ import {
   contentEn as schemaValidatorEn,
   contentJa as schemaValidatorJa,
 } from './content/api/schema-validator'
+import { contentEn as cliEn, contentJa as cliJa } from './content/cli'
 import { contentEn as conceptsEn, contentJa as conceptsJa } from './content/concepts'
 import {
   contentEn as gettingStartedEn,
   contentJa as gettingStartedJa,
 } from './content/getting-started'
+import {
+  contentEn as errorHandlingEn,
+  contentJa as errorHandlingJa,
+} from './content/guides/error-handling'
+import { contentEn as migrationEn, contentJa as migrationJa } from './content/guides/migration'
+import { contentEn as tursoEn, contentJa as tursoJa } from './content/guides/turso'
 import { contentEn as indexEn, contentJa as indexJa } from './content/index'
 import { renderMarkdown } from './markdown'
 
@@ -39,8 +46,6 @@ interface NavGroup {
   section: DocSection
   pages: DocPage[]
 }
-
-const PLACEHOLDER = '<p>This page is under construction.</p>'
 
 const indexHtml = renderMarkdown(indexEn)
 const indexHtmlJa = renderMarkdown(indexJa)
@@ -65,6 +70,14 @@ const escapeHatchHtml = renderMarkdown(escapeHatchEn)
 const escapeHatchHtmlJa = renderMarkdown(escapeHatchJa)
 const adaptersHtml = renderMarkdown(adaptersEn)
 const adaptersHtmlJa = renderMarkdown(adaptersJa)
+const migrationHtml = renderMarkdown(migrationEn)
+const migrationHtmlJa = renderMarkdown(migrationJa)
+const errorHandlingHtml = renderMarkdown(errorHandlingEn)
+const errorHandlingHtmlJa = renderMarkdown(errorHandlingJa)
+const tursoHtml = renderMarkdown(tursoEn)
+const tursoHtmlJa = renderMarkdown(tursoJa)
+const cliHtml = renderMarkdown(cliEn)
+const cliHtmlJa = renderMarkdown(cliJa)
 
 // 15 pages total
 export const docPages: readonly DocPage[] = [
@@ -167,25 +180,35 @@ export const docPages: readonly DocPage[] = [
     path: '/guides/migration',
     title: 'Migration Workflow',
     section: 'guides',
-    content: PLACEHOLDER,
+    description:
+      'End-to-end migration pipeline — model definitions, nanoka generate, drizzle-kit, and wrangler d1 migrations apply.',
+    content: migrationHtml,
+    contentJa: migrationHtmlJa,
   },
   {
     path: '/guides/error-handling',
     title: 'Error Handling',
     section: 'guides',
-    content: PLACEHOLDER,
+    description:
+      'HTTPException, app.onError, Zod validation errors, and patterns for safe error responses.',
+    content: errorHandlingHtml,
+    contentJa: errorHandlingHtmlJa,
   },
   {
     path: '/guides/turso',
     title: 'Using with Turso',
     section: 'guides',
-    content: PLACEHOLDER,
+    description: 'Switching to Turso/libSQL — setup, secrets, local development, and migrations.',
+    content: tursoHtml,
+    contentJa: tursoHtmlJa,
   },
   {
     path: '/cli',
     title: 'CLI Reference',
     section: 'cli',
-    content: PLACEHOLDER,
+    description: 'nanoka generate options, nanoka.config.ts, and the create-nanoka-app scaffolder.',
+    content: cliHtml,
+    contentJa: cliHtmlJa,
   },
 ] satisfies readonly DocPage[]
 


### PR DESCRIPTION
## Summary

- `site/src/content/guides/migration.ts` を新規作成 — パイプライン全体図・nanoka.config.ts/drizzle.config.ts・Option A/B/C・リモートデプロイ・モデル追加/フィールド変更手順・生成スキーマ例・t.json() 注意点（EN/JA）
- `site/src/content/guides/error-handling.ts` を新規作成 — HTTPException・グローバルエラーハンドラ・5xx スタックトレース隠蔽・Zod バリデーションエラー対策（validator hook / onError）・パスワードパターン・D1/Drizzle エラー・201/204/404 パターン集（EN/JA）
- `site/src/content/guides/turso.ts` を新規作成 — インストール・セットアップ・シークレット設定・ローカル開発・Turso 向けマイグレーション・D1 からの切り替え差分（EN/JA）
- `site/src/content/cli.ts` を新規作成 — nanoka generate オプション一覧・使用例・nanoka.config.ts 全オプション・create-nanoka-app 用法・生成ファイル一覧（EN/JA）
- `site/src/docs-registry.ts` を更新 — PLACEHOLDER を実コンテンツに差し替え・description 追加・PLACEHOLDER 定数削除
- `docs/implementation-status.md` を更新 — #62 完了エントリ追加

## Test plan

- [ ] lint エラーなし（`pnpm lint` — 74 warnings は既存コード由来）
- [ ] site typecheck 通過
- [ ] `/guides/migration` `/guides/error-handling` `/guides/turso` `/cli` の 4 URL で PLACEHOLDER が消えていること
- [ ] 言語トグルで EN/JA が切り替わること
- [ ] サイドバーに 4 ページが表示されること

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)