### PR TITLE
feat: Relations フィールドビルダー t.hasMany / t.belongsTo と型定義

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -60,7 +60,7 @@
 
 - Relations API (`t.hasMany()` / `t.belongsTo()` / `findMany({ with })`) — [#14](https://github.com/nanokajs/nanoka/issues/14)
   - 設計仕様: `docs/nanoka.md` "Relations API" 節
-  - フィールドビルダー実装 — #14-2
+  - フィールドビルダー実装 — #14-2 ✅ 完了（v1.7.0）
   - クエリ API 実装 — #14-3
   - 循環参照検出 — #14-4
   - docs-site 更新 — #14-5

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/codegen/__tests__/generate.test.ts
+++ b/packages/nanoka/src/codegen/__tests__/generate.test.ts
@@ -197,4 +197,23 @@ describe('generateDrizzleSchema', () => {
     const result = generateDrizzleSchema(models)
     expect(result).toMatchSnapshot()
   })
+
+  it('omits relation fields from generated schema', () => {
+    const PostModel = { fields: { id: t.integer(), title: t.string() }, tableName: 'posts' }
+    const models: ModelDef[] = [
+      {
+        name: 'users',
+        fields: {
+          id: t.uuid().primary(),
+          name: t.string(),
+          posts: t.hasMany(PostModel, { foreignKey: 'userId' }),
+        },
+      },
+    ]
+
+    const result = generateDrizzleSchema(models)
+    expect(result).not.toContain('posts')
+    expect(result).toContain('id')
+    expect(result).toContain('name')
+  })
 })

--- a/packages/nanoka/src/codegen/generate.ts
+++ b/packages/nanoka/src/codegen/generate.ts
@@ -17,6 +17,8 @@ function detectImports(
     for (const field of Object.values(model.fields)) {
       const kind = field.kind
 
+      if (kind === 'relation') continue
+
       if (kind === 'string' || kind === 'uuid' || kind === 'json') {
         imports.text = true
       } else if (kind === 'number') {
@@ -26,7 +28,8 @@ function detectImports(
       }
     }
 
-    if (Object.values(model.fields).length > 0) {
+    const nonRelationFields = Object.values(model.fields).filter((f) => f.kind !== 'relation')
+    if (nonRelationFields.length > 0) {
       imports.sqliteTable = true
     }
   }
@@ -64,7 +67,10 @@ export function generateDrizzleSchema(models: readonly ModelDef[]): string {
     const fieldLines: string[] = []
 
     for (const [fieldName, field] of Object.entries(model.fields)) {
-      fieldLines.push(renderField(fieldName, field))
+      const rendered = renderField(fieldName, field)
+      if (rendered !== null) {
+        fieldLines.push(rendered)
+      }
     }
 
     const fieldsStr = fieldLines.length > 0 ? fieldLines.join('\n') : ''

--- a/packages/nanoka/src/codegen/render-field.ts
+++ b/packages/nanoka/src/codegen/render-field.ts
@@ -1,6 +1,8 @@
 import type { Field } from '../field'
 
-export function renderField(fieldName: string, field: Field<any, any, any>): string {
+export function renderField(fieldName: string, field: Field<any, any, any>): string | null {
+  if (field.kind === 'relation') return null
+
   const lines: string[] = []
 
   const kind = field.kind

--- a/packages/nanoka/src/field/__tests__/relation.test.ts
+++ b/packages/nanoka/src/field/__tests__/relation.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import { defineModel } from '../../model'
 import { buildFieldAccessor } from '../../model/types'
 import { type RelationFieldBuilder, t } from '../factories'
-import { defineModel } from '../../model'
 
 const PostModel = { fields: { id: t.integer(), title: t.string() }, tableName: 'posts' }
-const CommentModel = { fields: { id: t.integer(), body: t.string() }, tableName: 'comments' }
+const _CommentModel = { fields: { id: t.integer(), body: t.string() }, tableName: 'comments' }
 
 describe('t.hasMany', () => {
   it('creates a relation field with kind relation and relationKind hasMany', () => {
@@ -44,7 +44,9 @@ describe('type-level tests', () => {
 
   it('t.belongsTo returns RelationFieldBuilder with belongsTo kind', () => {
     const field = t.belongsTo(PostModel, { foreignKey: 'postId' })
-    expectTypeOf(field).toMatchTypeOf<RelationFieldBuilder<typeof PostModel, 'postId', 'belongsTo'>>()
+    expectTypeOf(field).toMatchTypeOf<
+      RelationFieldBuilder<typeof PostModel, 'postId', 'belongsTo'>
+    >()
     expectTypeOf(field.relationKind).toEqualTypeOf<'belongsTo'>()
   })
 

--- a/packages/nanoka/src/field/__tests__/relation.test.ts
+++ b/packages/nanoka/src/field/__tests__/relation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { buildFieldAccessor } from '../../model/types'
+import { type RelationFieldBuilder, t } from '../factories'
+import { defineModel } from '../../model'
+
+const PostModel = { fields: { id: t.integer(), title: t.string() }, tableName: 'posts' }
+const CommentModel = { fields: { id: t.integer(), body: t.string() }, tableName: 'comments' }
+
+describe('t.hasMany', () => {
+  it('creates a relation field with kind relation and relationKind hasMany', () => {
+    const field = t.hasMany(PostModel, { foreignKey: 'userId' })
+    expect(field.kind).toBe('relation')
+    expect(field.relationKind).toBe('hasMany')
+    expect(field.foreignKey).toBe('userId')
+    expect(field.target).toBe(PostModel)
+  })
+
+  it('accepts a lazy target function', () => {
+    const field = t.hasMany(() => PostModel, { foreignKey: 'userId' })
+    expect(typeof field.target).toBe('function')
+  })
+
+  it('drizzleColumn throws an error', () => {
+    const field = t.hasMany(PostModel, { foreignKey: 'userId' })
+    expect(() => field.drizzleColumn('posts')).toThrow()
+  })
+})
+
+describe('t.belongsTo', () => {
+  it('creates a relation field with kind relation and relationKind belongsTo', () => {
+    const field = t.belongsTo(PostModel, { foreignKey: 'postId' })
+    expect(field.kind).toBe('relation')
+    expect(field.relationKind).toBe('belongsTo')
+    expect(field.foreignKey).toBe('postId')
+  })
+})
+
+describe('type-level tests', () => {
+  it('t.hasMany returns RelationFieldBuilder with hasMany kind', () => {
+    const field = t.hasMany(PostModel, { foreignKey: 'userId' })
+    expectTypeOf(field).toMatchTypeOf<RelationFieldBuilder<typeof PostModel, 'userId', 'hasMany'>>()
+    expectTypeOf(field.relationKind).toEqualTypeOf<'hasMany'>()
+  })
+
+  it('t.belongsTo returns RelationFieldBuilder with belongsTo kind', () => {
+    const field = t.belongsTo(PostModel, { foreignKey: 'postId' })
+    expectTypeOf(field).toMatchTypeOf<RelationFieldBuilder<typeof PostModel, 'postId', 'belongsTo'>>()
+    expectTypeOf(field.relationKind).toEqualTypeOf<'belongsTo'>()
+  })
+
+  it('buildFieldAccessor accessor does not include relation keys', () => {
+    const fields = {
+      id: t.integer(),
+      name: t.string(),
+      posts: t.hasMany(PostModel, { foreignKey: 'userId' }),
+    }
+    const accessor = buildFieldAccessor(fields)
+    expectTypeOf(accessor).toHaveProperty('id')
+    expectTypeOf(accessor).toHaveProperty('name')
+    expectTypeOf<keyof typeof accessor>().not.toEqualTypeOf<'posts'>()
+  })
+})
+
+describe('defineModel with relation fields', () => {
+  const UserModel = defineModel('users', {
+    id: t.integer().primary(),
+    name: t.string(),
+    posts: t.hasMany(PostModel, { foreignKey: 'userId' }),
+  })
+
+  it('User.table does not include relation keys', () => {
+    const tableColumns = Object.keys(UserModel.table)
+    expect(tableColumns).not.toContain('posts')
+    expect(tableColumns).toContain('id')
+    expect(tableColumns).toContain('name')
+  })
+
+  it('User.outputSchema().shape does not include relation keys', () => {
+    const shape = UserModel.outputSchema().shape
+    expect(shape).not.toHaveProperty('posts')
+    expect(shape).toHaveProperty('id')
+    expect(shape).toHaveProperty('name')
+  })
+
+  it('User.inputSchema("create").shape does not include relation keys', () => {
+    const shape = UserModel.inputSchema('create').shape
+    expect(shape).not.toHaveProperty('posts')
+    expect(shape).toHaveProperty('name')
+  })
+})

--- a/packages/nanoka/src/field/factories.ts
+++ b/packages/nanoka/src/field/factories.ts
@@ -3,7 +3,7 @@ import { integer, real, text } from 'drizzle-orm/sqlite-core'
 import type { z } from 'zod'
 import { z as zLib } from 'zod'
 import { BaseFieldBuilder } from './builder'
-import type { FieldModifiers } from './types'
+import type { FieldModifiers, RelationKind, RelationTargetLike } from './types'
 
 // ==================== StringFieldBuilder ====================
 
@@ -972,6 +972,36 @@ class JsonFieldBuilder<
   }
 }
 
+// ==================== RelationFieldBuilder ====================
+
+export class RelationFieldBuilder<
+  Target extends RelationTargetLike,
+  FK extends string,
+  Kind extends RelationKind,
+> {
+  readonly kind = 'relation' as const
+  readonly relationKind: Kind
+  readonly target: Target | (() => Target)
+  readonly foreignKey: FK
+  readonly tsType!: never
+  // biome-ignore lint/complexity/noBannedTypes: {} is used intentionally for empty modifiers
+  readonly modifiers = {} as const
+
+  constructor(relationKind: Kind, target: Target | (() => Target), foreignKey: FK) {
+    this.relationKind = relationKind
+    this.target = target
+    this.foreignKey = foreignKey
+  }
+
+  get zodBase(): z.ZodNever {
+    return zLib.never()
+  }
+
+  drizzleColumn(name: string): never {
+    throw new Error(`relation field '${name}' has no DB column`)
+  }
+}
+
 // ==================== Factory ====================
 
 // biome-ignore lint/complexity/noBannedTypes: {} is used intentionally for the default empty modifiers
@@ -1062,4 +1092,18 @@ export const t = {
    * Drizzle 型が欲しい場合は生成後に手動で書き換えるか `as` を使うこと。
    */
   json: jsonField,
+
+  hasMany<Target extends RelationTargetLike, FK extends string>(
+    target: Target | (() => Target),
+    options: { foreignKey: FK },
+  ): RelationFieldBuilder<Target, FK, 'hasMany'> {
+    return new RelationFieldBuilder('hasMany', target, options.foreignKey)
+  },
+
+  belongsTo<Target extends RelationTargetLike, FK extends string>(
+    target: Target | (() => Target),
+    options: { foreignKey: FK },
+  ): RelationFieldBuilder<Target, FK, 'belongsTo'> {
+    return new RelationFieldBuilder('belongsTo', target, options.foreignKey)
+  },
 }

--- a/packages/nanoka/src/field/index.ts
+++ b/packages/nanoka/src/field/index.ts
@@ -1,2 +1,12 @@
 export { t } from './factories'
-export type { Field, FieldModifiers, FieldPolicy, InferFieldType } from './types'
+export type { RelationFieldBuilder } from './factories'
+export type {
+  Field,
+  FieldModifiers,
+  FieldPolicy,
+  InferFieldType,
+  IsRelationField,
+  RelationDef,
+  RelationKind,
+  RelationTargetLike,
+} from './types'

--- a/packages/nanoka/src/field/index.ts
+++ b/packages/nanoka/src/field/index.ts
@@ -1,5 +1,5 @@
-export { t } from './factories'
 export type { RelationFieldBuilder } from './factories'
+export { t } from './factories'
 export type {
   Field,
   FieldModifiers,

--- a/packages/nanoka/src/field/types.ts
+++ b/packages/nanoka/src/field/types.ts
@@ -15,16 +15,30 @@ export interface FieldModifiers {
   policy?: FieldPolicy
 }
 
-export type FieldKind = 'string' | 'uuid' | 'number' | 'integer' | 'boolean' | 'timestamp' | 'json' | 'relation'
+export type FieldKind =
+  | 'string'
+  | 'uuid'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'timestamp'
+  | 'json'
+  | 'relation'
 
 export type RelationKind = 'hasMany' | 'belongsTo'
 
 export interface RelationTargetLike {
-  readonly fields: Record<string, { kind: FieldKind; zodBase: unknown; drizzleColumn(name: string): unknown }>
+  readonly fields: Record<
+    string,
+    { kind: FieldKind; zodBase: unknown; drizzleColumn(name: string): unknown }
+  >
   readonly tableName: string
 }
 
-export interface RelationDef<Target extends RelationTargetLike = RelationTargetLike, FK extends string = string> {
+export interface RelationDef<
+  Target extends RelationTargetLike = RelationTargetLike,
+  FK extends string = string,
+> {
   readonly kind: 'relation'
   readonly relationKind: RelationKind
   readonly target: Target | (() => Target)

--- a/packages/nanoka/src/field/types.ts
+++ b/packages/nanoka/src/field/types.ts
@@ -15,7 +15,28 @@ export interface FieldModifiers {
   policy?: FieldPolicy
 }
 
-export type FieldKind = 'string' | 'uuid' | 'number' | 'integer' | 'boolean' | 'timestamp' | 'json'
+export type FieldKind = 'string' | 'uuid' | 'number' | 'integer' | 'boolean' | 'timestamp' | 'json' | 'relation'
+
+export type RelationKind = 'hasMany' | 'belongsTo'
+
+export interface RelationTargetLike {
+  readonly fields: Record<string, { kind: FieldKind; zodBase: unknown; drizzleColumn(name: string): unknown }>
+  readonly tableName: string
+}
+
+export interface RelationDef<Target extends RelationTargetLike = RelationTargetLike, FK extends string = string> {
+  readonly kind: 'relation'
+  readonly relationKind: RelationKind
+  readonly target: Target | (() => Target)
+  readonly foreignKey: FK
+  readonly tsType: never
+  readonly zodBase: z.ZodNever
+  // biome-ignore lint/complexity/noBannedTypes: {} is used intentionally for empty modifiers
+  readonly modifiers: {}
+  drizzleColumn(name: string): never
+}
+
+export type IsRelationField<F> = F extends { kind: 'relation' } ? true : false
 
 /**
  * Represents a typed database field with Zod validation and Drizzle column mapping.

--- a/packages/nanoka/src/index.ts
+++ b/packages/nanoka/src/index.ts
@@ -1,6 +1,16 @@
 export type { Adapter } from './adapter'
 export { d1Adapter } from './adapter'
-export type { Field, FieldModifiers, FieldPolicy, InferFieldType, IsRelationField, RelationDef, RelationFieldBuilder, RelationKind, RelationTargetLike } from './field'
+export type {
+  Field,
+  FieldModifiers,
+  FieldPolicy,
+  InferFieldType,
+  IsRelationField,
+  RelationDef,
+  RelationFieldBuilder,
+  RelationKind,
+  RelationTargetLike,
+} from './field'
 export { t } from './field'
 export type {
   CreateInput,

--- a/packages/nanoka/src/index.ts
+++ b/packages/nanoka/src/index.ts
@@ -1,6 +1,6 @@
 export type { Adapter } from './adapter'
 export { d1Adapter } from './adapter'
-export type { Field, FieldModifiers, FieldPolicy, InferFieldType } from './field'
+export type { Field, FieldModifiers, FieldPolicy, InferFieldType, IsRelationField, RelationDef, RelationFieldBuilder, RelationKind, RelationTargetLike } from './field'
 export { t } from './field'
 export type {
   CreateInput,

--- a/packages/nanoka/src/model/define.ts
+++ b/packages/nanoka/src/model/define.ts
@@ -16,6 +16,7 @@ import type {
   FindManyOptions,
   IdOrWhere,
   Model,
+  NonRelationKeys,
   RowType,
   SchemaOptions,
 } from './types'
@@ -49,7 +50,7 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
     tableName,
     table,
 
-    schema<Opts extends SchemaOptions<keyof Fields & string> | undefined>(
+    schema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined>(
       opts?: Opts,
     ): Apply<FieldsToZodShape<Fields>, Opts> {
       const baseSchema = buildBaseObject(fields)
@@ -60,7 +61,7 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
 
     validator(
       target: keyof ValidationTargets,
-      optsOrPreset?: 'create' | 'update' | SchemaOptions<keyof Fields & string>,
+      optsOrPreset?: 'create' | 'update' | SchemaOptions<NonRelationKeys<Fields> & string>,
       // biome-ignore lint/suspicious/noExplicitAny: Hook<T> is contravariant in T; any is required to bridge overload implementations
       hook?: Hook<any, Env, string, keyof ValidationTargets>,
     ) {
@@ -68,7 +69,7 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
       if (optsOrPreset === 'create' || optsOrPreset === 'update') {
         schema = this.inputSchema(optsOrPreset)
       } else {
-        schema = this.schema(optsOrPreset as SchemaOptions<keyof Fields & string>)
+        schema = this.schema(optsOrPreset as SchemaOptions<NonRelationKeys<Fields> & string>)
       }
       // biome-ignore lint/suspicious/noExplicitAny: zValidator return type cast required at overload boundary
       return zValidator(target, schema, hook) as any
@@ -76,7 +77,7 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
 
     inputSchema(
       usage: 'create' | 'update',
-      opts?: SchemaOptions<keyof Fields & string>,
+      opts?: SchemaOptions<NonRelationKeys<Fields> & string>,
       // biome-ignore lint/suspicious/noExplicitAny: precise return type is enforced by Model<Fields> overload signatures
     ): any {
       const merged = derivePolicyOptions(
@@ -90,7 +91,7 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
     },
 
     outputSchema(
-      opts?: SchemaOptions<keyof Fields & string>,
+      opts?: SchemaOptions<NonRelationKeys<Fields> & string>,
       // biome-ignore lint/suspicious/noExplicitAny: precise return type is enforced by Model<Fields> overload signatures
     ): any {
       const merged = derivePolicyOptions(fields, 'output', opts, accessor)

--- a/packages/nanoka/src/model/schema.ts
+++ b/packages/nanoka/src/model/schema.ts
@@ -22,6 +22,21 @@ function computeForcedOmit(
 }
 
 /**
+ * Returns field names for relation fields that must always be omitted from API schemas.
+ * Relation fields have no DB column and no Zod schema representation.
+ */
+function computeRelationOmit(
+  // biome-ignore lint/suspicious/noExplicitAny: any is necessary for generic Field handling
+  fields: Record<string, Field<any, any, any>>,
+): Set<string> {
+  const keys = new Set<string>()
+  for (const [key, field] of Object.entries(fields)) {
+    if (field.kind === 'relation') keys.add(key)
+  }
+  return keys
+}
+
+/**
  * Returns field names to omit based on UX-oriented policy (writeOnly / readOnly).
  * These can be overridden when user explicitly provides pick.
  *
@@ -66,7 +81,9 @@ export function derivePolicyOptions(
   // biome-ignore lint/suspicious/noExplicitAny: accessor is a plain object with string keys
   accessor?: FieldAccessor<any>,
 ): SchemaOptions {
-  const forced = computeForcedOmit(fields)
+  const forcedBase = computeForcedOmit(fields)
+  const relationOmit = computeRelationOmit(fields)
+  const forced = [...new Set([...forcedBase, ...relationOmit])]
   const optional = computeOptionalOmit(fields, usage)
 
   const acc = accessor ?? ({} as FieldAccessor<string>)
@@ -102,12 +119,14 @@ export function derivePolicyOptions(
 /**
  * Builds a Zod object schema from a fields definition.
  * Returns a ZodObject with all fields required and present.
+ * Relation fields are excluded as they have no Zod schema representation.
  */
 // biome-ignore lint/suspicious/noExplicitAny: any is necessary for generic Field handling and Zod shape
 export function buildBaseObject(fields: Record<string, Field<any, any, any>>): z.ZodObject<any> {
   // biome-ignore lint/suspicious/noExplicitAny: Record key-value pairs have any type for shape
   const shape: Record<string, any> = {}
   for (const [key, field] of Object.entries(fields)) {
+    if (field.kind === 'relation') continue
     shape[key] = field.zodBase
   }
   return z.object(shape)

--- a/packages/nanoka/src/model/table.ts
+++ b/packages/nanoka/src/model/table.ts
@@ -4,12 +4,13 @@ import {
   sqliteTable,
 } from 'drizzle-orm/sqlite-core'
 import type { Field } from '../field/types'
+import type { NonRelationKeys } from './types'
 
 // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
 type ModelTable<Fields extends Record<string, Field<any, any, any>>> = SQLiteTableWithColumns<{
   name: string
   schema: undefined
-  columns: { [K in keyof Fields]: AnySQLiteColumn }
+  columns: { [K in NonRelationKeys<Fields>]: AnySQLiteColumn }
   dialect: 'sqlite'
 }>
 
@@ -25,6 +26,7 @@ export function buildTable<Fields extends Record<string, Field<any, any, any>>>(
 ): ModelTable<Fields> {
   const columns: Record<string, any> = {}
   for (const [key, field] of Object.entries(fields)) {
+    if (field.kind === 'relation') continue
     columns[key] = field.drizzleColumn(key)
   }
   return sqliteTable(tableName, columns) as unknown as ModelTable<Fields>

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -8,6 +8,16 @@ import type { Field, FieldPolicy, InferFieldType } from '../field/types'
 import type { OpenAPIModelComponent, OpenAPISchemaObject, OpenAPIUsage } from '../openapi/types'
 
 /**
+ * @internal
+ * Extracts keys of non-relation fields from a Fields record.
+ * Relation fields (kind: 'relation') are excluded from DB column types, RowType, etc.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
+export type NonRelationKeys<Fields extends Record<string, Field<any, any, any>>> = {
+  [K in keyof Fields]: Fields[K] extends { kind: 'relation' } ? never : K
+}[keyof Fields]
+
+/**
  * Options for findMany query.
  * `limit` is required (no default).
  * `offset` defaults to 0 if omitted.
@@ -45,11 +55,11 @@ export type OrderBy<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
 > =
-  | (keyof Fields & string)
-  | { readonly column: keyof Fields & string; readonly direction?: 'asc' | 'desc' }
+  | (NonRelationKeys<Fields> & string)
+  | { readonly column: NonRelationKeys<Fields> & string; readonly direction?: 'asc' | 'desc' }
   | ReadonlyArray<
-      | (keyof Fields & string)
-      | { readonly column: keyof Fields & string; readonly direction?: 'asc' | 'desc' }
+      | (NonRelationKeys<Fields> & string)
+      | { readonly column: NonRelationKeys<Fields> & string; readonly direction?: 'asc' | 'desc' }
     >
 
 /**
@@ -59,7 +69,7 @@ export type Where<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
 > = {
-  readonly [K in keyof Fields]?: InferFieldType<Fields[K]>
+  readonly [K in NonRelationKeys<Fields>]?: InferFieldType<Fields[K]>
 }
 
 /**
@@ -71,17 +81,17 @@ export type IdOrWhere<
 > = string | number | Where<Fields>
 
 /**
- * Row type: full record type from fields.
+ * Row type: full record type from fields, excluding relation fields.
  */
 export type RowType<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
 > = {
-  [K in keyof Fields]: InferFieldType<Fields[K]>
+  [K in NonRelationKeys<Fields>]: InferFieldType<Fields[K]>
 }
 
 /**
- * Drizzle table type with columns typed to match the model's Fields.
+ * Drizzle table type with columns typed to match the model's Fields (excluding relation fields).
  * Allows type-safe column access via Model.table.fieldName.
  */
 // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
@@ -89,7 +99,7 @@ export type ModelTable<Fields extends Record<string, Field<any, any, any>>> =
   SQLiteTableWithColumns<{
     name: string
     schema: undefined
-    columns: { [K in keyof Fields]: AnySQLiteColumn }
+    columns: { [K in NonRelationKeys<Fields>]: AnySQLiteColumn }
     dialect: 'sqlite'
   }>
 
@@ -192,18 +202,19 @@ type IsRequired<F extends Field<any, any, any>> =
  * - all other fields are required
  * - `serverOnly` fields are completely excluded (cannot be passed even internally)
  * - `writeOnly` fields are included as required (they are input fields by design)
+ * - relation fields are completely excluded (no DB column)
  */
 export type CreateInput<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
 > = {
-  [K in keyof Fields as IsRequired<Fields[K]> extends true
+  [K in NonRelationKeys<Fields> as IsRequired<Fields[K]> extends true
     ? K extends ServerOnlyKeys<Fields>
       ? never
       : K
     : never]: InferFieldType<Fields[K]>
 } & {
-  [K in keyof Fields as IsRequired<Fields[K]> extends true
+  [K in NonRelationKeys<Fields> as IsRequired<Fields[K]> extends true
     ? never
     : K extends ServerOnlyKeys<Fields>
       ? never
@@ -234,20 +245,26 @@ export function resolveSchemaOptionKeys<K extends string>(
 /**
  * @internal
  * Builds a frozen field accessor object for use in schema/validator options.
- * Each key maps to itself, providing typo detection at type level.
+ * Relation fields are excluded so that `omit: f => [f.posts]` is a type error.
+ * Each non-relation key maps to itself, providing typo detection at type level.
  */
-export function buildFieldAccessor<Fields extends Record<string, unknown>>(
+// biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
+export function buildFieldAccessor<Fields extends Record<string, Field<any, any, any>>>(
   fields: Fields,
-): { readonly [K in keyof Fields]: K } {
+): { readonly [K in NonRelationKeys<Fields>]: K } {
   const acc: Record<string, string> = {}
-  for (const k of Object.keys(fields)) acc[k] = k
-  return Object.freeze(acc) as { readonly [K in keyof Fields]: K }
+  for (const [k, field] of Object.entries(fields)) {
+    if (field.kind === 'relation') continue
+    acc[k] = k
+  }
+  return Object.freeze(acc) as { readonly [K in NonRelationKeys<Fields>]: K }
 }
 
 /**
  * @internal
  * Extracts a Zod shape from fields for the Apply type.
- * Each field's zodBase becomes a property in the shape.
+ * Only non-relation fields are included (relation fields have zodBase: ZodNever
+ * and are skipped at runtime in buildBaseObject).
  * Indexed access ensures concrete Zod types are preserved (not `any`).
  */
 export type FieldsToZodShape<
@@ -257,7 +274,7 @@ export type FieldsToZodShape<
     Field<any, any, any>
   >,
 > = {
-  [K in keyof Fields]: Fields[K]['zodBase']
+  [K in NonRelationKeys<Fields>]: Fields[K]['zodBase']
 }
 
 /**
@@ -442,7 +459,7 @@ export type ModelValidatorReturn<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
   Target extends keyof ValidationTargets,
-  Opts extends SchemaOptions<keyof Fields & string> | undefined,
+  Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined,
 > = MiddlewareHandler<
   any,
   string,
@@ -477,7 +494,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    * const CreateSchema = User.schema({ omit: ['passwordHash'] })
    * const UpdateSchema = User.schema({ partial: true, pick: ['name', 'email'] })
    */
-  schema<Opts extends SchemaOptions<keyof Fields & string> | undefined>(
+  schema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined>(
     opts?: Opts,
   ): Apply<FieldsToZodShape<Fields>, Opts>
 
@@ -542,7 +559,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
   >
   validator<
     Target extends keyof ValidationTargets,
-    Opts extends SchemaOptions<keyof Fields & string> | undefined,
+    Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined,
     E extends Env = Env,
     P extends string = string,
   >(
@@ -558,7 +575,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    *
    * The return type precisely reflects policy-derived omissions using PolicyOmitKeys.
    */
-  inputSchema<Opts extends SchemaOptions<keyof Fields & string> | undefined = undefined>(
+  inputSchema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined>(
     usage: 'create',
     opts?: Opts,
   ): z.ZodObject<
@@ -567,7 +584,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
       Opts
     >
   >
-  inputSchema<Opts extends SchemaOptions<keyof Fields & string> | undefined = undefined>(
+  inputSchema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined>(
     usage: 'update',
     opts?: Opts,
   ): z.ZodObject<
@@ -578,7 +595,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
   >
   inputSchema(
     usage: 'create' | 'update',
-    opts?: SchemaOptions<keyof Fields & string>,
+    opts?: SchemaOptions<NonRelationKeys<Fields> & string>,
   ): z.ZodObject<z.ZodRawShape>
 
   /**
@@ -588,7 +605,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    *
    * The return type precisely reflects policy-derived omissions using PolicyOmitKeys.
    */
-  outputSchema<Opts extends SchemaOptions<keyof Fields & string> | undefined = undefined>(
+  outputSchema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined>(
     opts?: Opts,
   ): z.ZodObject<
     ApplyShape<Omit<FieldsToZodShape<Fields>, PolicyOmitKeys<Fields, 'output'> & string>, Opts>

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -605,7 +605,9 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
    *
    * The return type precisely reflects policy-derived omissions using PolicyOmitKeys.
    */
-  outputSchema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined>(
+  outputSchema<
+    Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined,
+  >(
     opts?: Opts,
   ): z.ZodObject<
     ApplyShape<Omit<FieldsToZodShape<Fields>, PolicyOmitKeys<Fields, 'output'> & string>, Opts>

--- a/packages/nanoka/src/openapi/__tests__/openapi.test.ts
+++ b/packages/nanoka/src/openapi/__tests__/openapi.test.ts
@@ -196,4 +196,21 @@ describe('OpenAPI component generation', () => {
   it('matches snapshot', () => {
     expect(User.toOpenAPIComponent()).toMatchSnapshot()
   })
+
+  it('omits relation fields from OpenAPI schema', () => {
+    const PostModel = { fields: { id: t.integer(), title: t.string() }, tableName: 'posts' }
+    const UserWithRelation = defineModel('users', {
+      id: t.uuid().primary().readOnly(),
+      name: t.string(),
+      posts: t.hasMany(PostModel, { foreignKey: 'userId' }),
+    })
+
+    const component = UserWithRelation.toOpenAPIComponent()
+
+    expect(component.create.properties).not.toHaveProperty('posts')
+    expect(component.update.properties).not.toHaveProperty('posts')
+    expect(component.output.properties).not.toHaveProperty('posts')
+    expect(component.output.properties).toHaveProperty('id')
+    expect(component.output.properties).toHaveProperty('name')
+  })
 })

--- a/packages/nanoka/src/openapi/generate.ts
+++ b/packages/nanoka/src/openapi/generate.ts
@@ -39,6 +39,7 @@ export function toOpenAPISchema(
   for (const [key, zodSchema] of Object.entries(shape)) {
     const field = fields[key]
     if (field === undefined) continue
+    if (field.kind === 'relation') continue
 
     properties[key] = fieldToOpenAPISchema(field, opts?.strict)
     if (field.modifiers.policy === 'writeOnly' && (usage === 'create' || usage === 'update')) {

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -85,7 +85,7 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
       validator: (
         ...args: [
           keyof import('hono').ValidationTargets,
-          ('create' | 'update' | import('../model/types').SchemaOptions<keyof Fields & string>)?,
+          ('create' | 'update' | import('../model/types').SchemaOptions<import('../model/types').NonRelationKeys<Fields> & string>)?,
           import('@hono/zod-validator').Hook<
             // biome-ignore lint/suspicious/noExplicitAny: Hook<T> is contravariant in T; any is required to bridge overload implementations
             any,

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -85,7 +85,13 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
       validator: (
         ...args: [
           keyof import('hono').ValidationTargets,
-          ('create' | 'update' | import('../model/types').SchemaOptions<import('../model/types').NonRelationKeys<Fields> & string>)?,
+          (
+            | 'create'
+            | 'update'
+            | import('../model/types').SchemaOptions<
+                import('../model/types').NonRelationKeys<Fields> & string
+              >
+          )?,
           import('@hono/zod-validator').Hook<
             // biome-ignore lint/suspicious/noExplicitAny: Hook<T> is contravariant in T; any is required to bridge overload implementations
             any,

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -13,6 +13,7 @@ import type {
   IdOrWhere,
   ModelTable,
   ModelValidatorReturn,
+  NonRelationKeys,
   PolicyOmitKeys,
   RowType,
   SchemaOptions,
@@ -45,7 +46,7 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
    * Returns a Zod schema derived from this model's fields.
    * Supports pick, omit, and partial transformations.
    */
-  schema<Opts extends SchemaOptions<keyof Fields & string> | undefined = undefined>(
+  schema<Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined>(
     opts?: Opts,
   ): Apply<FieldsToZodShape<Fields>, Opts>
 
@@ -102,7 +103,7 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
   >
   validator<
     Target extends keyof import('hono').ValidationTargets,
-    Opts extends SchemaOptions<keyof Fields & string> | undefined = undefined,
+    Opts extends SchemaOptions<NonRelationKeys<Fields> & string> | undefined = undefined,
     E extends Env = Env,
     P extends string = string,
   >(
@@ -116,13 +117,13 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
    */
   inputSchema(
     usage: 'create' | 'update',
-    opts?: SchemaOptions<keyof Fields & string>,
+    opts?: SchemaOptions<NonRelationKeys<Fields> & string>,
   ): z.ZodObject<z.ZodRawShape>
 
   /**
    * Returns a Zod schema for API output, with policy-based field exclusions applied.
    */
-  outputSchema(opts?: SchemaOptions<keyof Fields & string>): z.ZodObject<z.ZodRawShape>
+  outputSchema(opts?: SchemaOptions<NonRelationKeys<Fields> & string>): z.ZodObject<z.ZodRawShape>
 
   /**
    * Parses a DB row through outputSchema and returns the safe response object.


### PR DESCRIPTION
## Summary

- `RelationDef<Target, FK>` / `RelationKind` / `RelationTargetLike` / `IsRelationField` を `field/types.ts` に追加
- `FieldKind` に `'relation'` を追加し、`t.hasMany()` / `t.belongsTo()` ファクトリを実装（遅延評価 `() => Target` 対応）
- `NonRelationKeys<Fields>` を導入し、`RowType` / `Where` / `OrderBy` / `CreateInput` / `FieldsToZodShape` / `buildFieldAccessor` / `SchemaOptions` の型パラメータから relation キーを除外
- `buildTable` / `buildBaseObject` / `derivePolicyOptions` / OpenAPI 生成 / codegen で relation フィールドを skip（DB 列を生成しない）
- unit tests（runtime + type-level）を追加、typecheck / workers 380 tests / node 32 tests すべて pass

## 変更ファイル

- `packages/nanoka/src/field/types.ts` — 新型定義
- `packages/nanoka/src/field/factories.ts` — ファクトリ実装
- `packages/nanoka/src/field/index.ts` / `src/index.ts` — 再エクスポート
- `packages/nanoka/src/model/types.ts` — `NonRelationKeys`, `FieldsToZodShape`, `buildFieldAccessor`, 型パラメータ更新
- `packages/nanoka/src/model/define.ts` / `table.ts` / `schema.ts` — relation skip
- `packages/nanoka/src/router/types.ts` / `router/nanoka.ts` — 型パラメータ更新
- `packages/nanoka/src/openapi/generate.ts` / `codegen/render-field.ts` / `codegen/generate.ts` — relation skip
- `packages/nanoka/src/field/__tests__/relation.test.ts` — 新規テスト
- `packages/nanoka/src/codegen/__tests__/generate.test.ts` / `openapi/__tests__/openapi.test.ts` — relation ケース追加
- `packages/nanoka/package.json` / `packages/create-nanoka-app/package.json` — 1.6.1 → 1.7.0
- `docs/implementation-status.md` — #14-2 完了済みに更新

## 見送り（後続 Issue）

- `findMany({ with })` クエリ実装 → #14-3
- 循環参照検出 → #14-4
- docs-site 更新 → #14-5（全 Relations API 完成後）

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)