### PR TITLE
fix: allow depth-1 with on bidirectional relations

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -62,7 +62,7 @@
   - 設計仕様: `docs/nanoka.md` "Relations API" 節
   - フィールドビルダー実装 — #14-2 ✅ 完了（v1.7.0）
   - クエリ API 実装 — #83 ✅ 完了（v1.8.0）
-  - 循環参照検出 — #83 ✅ 完了（v1.8.0）
+  - depth 1 `with` で双方向 relation graph を許容 — #89 ✅ 完了（v1.8.0）
   - docs-site 更新 — #14-5
 
 ## Non-goal（全 Phase 外）

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -380,7 +380,7 @@ findOne(adapter, id, { with: { author: true } })
 | 制約 | 内容 |
 |---|---|
 | Depth | 1 のみ。ネスト `with` は v1 対象外（#14 で再検討） |
-| 循環参照 | `Target` 関数遅延評価で TDZ 回避。`with` クエリ時に DFS で循環を検出してエラー（実装は #14-4） |
+| 循環参照 | `Target` 関数遅延評価で TDZ 回避。depth 1 eager loading では指定された関係のみ取得し、関係先から逆方向へ再帰しないため、双方向 relation graph も許容する |
 | `findMany.limit` | 親クエリには必須維持。関係先には適用しない（known limitation） |
 | `where` DSL | 関係先カラムでの絞り込みは未対応。`app.db` を使う |
 | マイグレーション | 外部キー制約 SQL を自動生成しない（Load-bearing rule 1 維持）。Drizzle schema の `references()` は手動で追加する |
@@ -392,7 +392,7 @@ findOne(adapter, id, { with: { author: true } })
 
 - **#14-2**: フィールドビルダー実装（`t.hasMany` / `t.belongsTo` の型と builder）。`Field` 型に `kind: 'relation'` discriminator を追加し、codegen・schema 派生から除外する分岐を実装
 - **#14-3**: `findMany({ with })` / `findOne({ with })` のクエリ実装。`packages/nanoka/src/model/types.ts` と `packages/nanoka/src/router/types.ts` の両層を同時更新（CLAUDE.md Load-bearing rule に従う）
-- **#14-4**: 循環参照 DFS 検出とエラー設計
+- **#14-4 / #89**: depth 1 eager loading では双方向 relation graph を許容。ネスト `with` 導入時に必要なら循環参照検出を再検討
 - **#14-5**: docs-site の例とドキュメントサイト更新
 
 ---

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Depth-1 relation eager loading via `findMany(adapter, { limit, with })` and `findOne(adapter, idOrWhere, { with })`.
 - Typed `WithOptions`, `WithResult`, `RelationKeys`, and `FindOneOptions` exports for relation query results.
-- Runtime `with` validation and relation graph cycle detection for relation eager loading.
+- Runtime `with` validation for relation eager loading.
+- Bidirectional relation graphs are supported for depth-1 eager loading.
 
 ### Notes
 
-- Relation loading follows the documented parent query + relation query + JavaScript grouping strategy; nested eager loading remains out of scope.
+- Relation loading follows the documented parent query + relation query + JavaScript grouping strategy; nested eager loading and recursive relation graph traversal remain out of scope.
 
 ## [1.6.0] — 2026-05-05
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -673,22 +673,39 @@ describe('relation eager loading', () => {
     ).rejects.toThrow(HTTPException)
   })
 
-  it('detects cyclic relation graphs on with query', async () => {
+  it('allows depth-1 hasMany loading on bidirectional relation graphs', async () => {
     const { env } = await import('cloudflare:test')
     const adapter = d1Adapter(env.DB)
 
-    await expect(CycleUser.findMany(adapter, { limit: 10, with: { posts: true } })).rejects.toThrow(
-      /relation cycle detected/,
-    )
+    const users = await CycleUser.findMany(adapter, {
+      limit: 10,
+      with: { posts: true },
+    })
+
+    expect(users).toHaveLength(1)
+    expect(users[0]!.posts.map((post: { id: string }) => post.id)).toEqual(['cp-1'])
   })
 
-  it('detects cyclic relation graphs on findOne with missing parent row', async () => {
+  it('allows depth-1 belongsTo loading on bidirectional relation graphs', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const posts = await CyclePost.findMany(adapter, {
+      limit: 10,
+      with: { user: true },
+    })
+
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.user?.id).toBe('cu-1')
+  })
+
+  it('returns null for findOne with missing parent row and with option', async () => {
     const { env } = await import('cloudflare:test')
     const adapter = d1Adapter(env.DB)
 
     await expect(
       CycleUser.findOne(adapter, 'missing-user', { with: { posts: true } }),
-    ).rejects.toThrow(/relation cycle detected/)
+    ).resolves.toBeNull()
   })
 })
 

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -707,6 +707,20 @@ describe('relation eager loading', () => {
       CycleUser.findOne(adapter, 'missing-user', { with: { posts: true } }),
     ).resolves.toBeNull()
   })
+
+  it('validates findOne with option before returning null for missing parent rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await expect(
+      CycleUser.findOne(adapter, 'missing-user', {
+        with: { posts: { with: { user: true } } },
+      } as any),
+    ).rejects.toThrow(HTTPException)
+    await expect(
+      CycleUser.findOne(adapter, 'missing-user', { with: { name: true } } as any),
+    ).rejects.toThrow(HTTPException)
+  })
 })
 
 describe('findAll', () => {

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -446,13 +446,16 @@ export async function findOneImpl<Fields extends Record<string, Field<any, any, 
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }
 
+  if (options?.with !== undefined) {
+    validateWithOptions(fields, options.with as Record<string, unknown>)
+  }
+
   // biome-ignore lint/suspicious/noExplicitAny: drizzle query type
   const rows = await (adapter.drizzle.select().from(table).where(whereClause).limit(1) as any)
   if (rows.length === 0) {
     return null
   }
   if (options?.with !== undefined) {
-    validateWithOptions(fields, options.with as Record<string, unknown>)
     const withRows = await loadRelations(adapter, table, fields, [rows[0]], options.with)
     return withRows[0] ?? null
   }

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -142,55 +142,6 @@ function validateWithOptions(
   }
 }
 
-const relationCycleCache = new WeakMap<object, Error | null>()
-
-function assertNoRelationCycle(
-  fields: Record<string, Field<any, any, any>>,
-  rootName = 'root',
-): void {
-  const cached = relationCycleCache.get(fields)
-  if (cached !== undefined) {
-    if (cached !== null) throw cached
-    return
-  }
-
-  const visiting = new Set<object>()
-  const visited = new Set<object>()
-
-  const visit = (
-    currentFields: Record<string, Field<any, any, any>>,
-    path: readonly string[],
-  ): Error | null => {
-    if (visiting.has(currentFields)) {
-      return new HTTPException(500, { message: 'relation cycle detected' })
-    }
-    if (visited.has(currentFields)) {
-      return null
-    }
-
-    visiting.add(currentFields)
-    for (const field of Object.values(currentFields)) {
-      if (field.kind !== 'relation') continue
-
-      const target = resolveRelationTarget(field as RelationDef)
-      const targetFields = target.fields as Record<string, Field<any, any, any>>
-      const error = visit(targetFields, [...path, target.tableName])
-      if (error !== null) {
-        return error
-      }
-    }
-    visiting.delete(currentFields)
-    visited.add(currentFields)
-    return null
-  }
-
-  const error = visit(fields, [rootName])
-  relationCycleCache.set(fields, error)
-  if (error !== null) {
-    throw error
-  }
-}
-
 async function loadRelations<
   Fields extends Record<string, Field<any, any, any>>,
   With extends WithOptions<Fields>,
@@ -383,7 +334,6 @@ export async function findManyImpl<
   const rows = await query
   if (options.with !== undefined) {
     validateWithOptions(fields, options.with as Record<string, unknown>)
-    assertNoRelationCycle(fields)
     return loadRelations(adapter, table, fields, rows, options.with as NonNullable<With>)
   }
   return rows
@@ -496,17 +446,13 @@ export async function findOneImpl<Fields extends Record<string, Field<any, any, 
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }
 
-  if (options?.with !== undefined) {
-    validateWithOptions(fields, options.with as Record<string, unknown>)
-    assertNoRelationCycle(fields)
-  }
-
   // biome-ignore lint/suspicious/noExplicitAny: drizzle query type
   const rows = await (adapter.drizzle.select().from(table).where(whereClause).limit(1) as any)
   if (rows.length === 0) {
     return null
   }
   if (options?.with !== undefined) {
+    validateWithOptions(fields, options.with as Record<string, unknown>)
     const withRows = await loadRelations(adapter, table, fields, [rows[0]], options.with)
     return withRows[0] ?? null
   }


### PR DESCRIPTION
## Summary
- remove the global relation graph cycle guard from depth-1 with execution
- allow bidirectional hasMany/belongsTo graphs for depth-1 eager loading
- keep nested with rejected and restore findOne missing parent behavior to return null
- update relation docs/status/changelog to match the depth-1 semantics

## Tests
- pnpm -C packages/nanoka exec vitest run -c vitest.config.ts src/model/__tests__/crud.integration.test.ts
- pnpm -C packages/nanoka typecheck

Closes #89