### PR TITLE
feat: add toOpenAPISchema with option for relations nested expansion

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -37,6 +37,7 @@
 - `findMany` の `where` に Drizzle SQL 式を渡せるオーバーロード — [#39](https://github.com/nanokajs/nanoka/issues/39)
 - `Model.toResponseMany(rows)` ヘルパ — [#39](https://github.com/nanokajs/nanoka/issues/39)
 - `Model.findAll(adapter, options?)` — LIMIT なし全件取得。`findMany` の `MAX_LIMIT = 100` ランタイムキャップを廃止 — [#49](https://github.com/nanokajs/nanoka/issues/49)
+- `toOpenAPISchema('output', { with })` による relations nested 展開（spec-only、runtime は Zod のまま） — [#91](https://github.com/nanokajs/nanoka/issues/91)
 
 ### AI coding support
 
@@ -63,6 +64,7 @@
   - フィールドビルダー実装 — #14-2 ✅ 完了（v1.7.0）
   - クエリ API 実装 — #83 ✅ 完了（v1.8.0）
   - depth 1 `with` で双方向 relation graph を許容 — #89 ✅ 完了（v1.8.0）
+  - `toOpenAPISchema('output', { with })` による relations nested 展開（spec-only、runtime は Zod のまま） — [#91](https://github.com/nanokajs/nanoka/issues/91) ✅ 完了
   - docs-site 更新 — #14-5
 
 ## Non-goal（全 Phase 外）

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -384,7 +384,7 @@ findOne(adapter, id, { with: { author: true } })
 | `findMany.limit` | 親クエリには必須維持。関係先には適用しない（known limitation） |
 | `where` DSL | 関係先カラムでの絞り込みは未対応。`app.db` を使う |
 | マイグレーション | 外部キー制約 SQL を自動生成しない（Load-bearing rule 1 維持）。Drizzle schema の `references()` は手動で追加する |
-| OpenAPI | relation フィールドは `outputSchema()` に含めない（v1）。`with` 指定時の出力型表現は v2 で検討 |
+| OpenAPI | `outputSchema()` への relation 自動展開は v1 対象外。`toOpenAPISchema('output', { with })` による spec-only 展開は v1.9.0 で追加。runtime validation source of truth は Zod のまま |
 | Validator | `validator()` / `inputSchema()` / `outputSchema()` の派生から自動除外される |
 | Escape hatch | 複雑な JOIN・集計は `app.db` を使う方針を維持（Load-bearing rule 4） |
 

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/index.ts
+++ b/packages/nanoka/src/index.ts
@@ -40,6 +40,7 @@ export type {
   OpenAPISpecOptions,
   OpenAPIUsage,
   RouteOpenAPIMetadata,
+  WithOpenAPIOption,
 } from './openapi'
 export { swaggerUI } from './openapi'
 export type { Nanoka, NanokaModel, RouteOpenAPIOption } from './router'

--- a/packages/nanoka/src/model/define.ts
+++ b/packages/nanoka/src/model/define.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod'
 import type { Adapter } from '../adapter/types'
 import type { Field } from '../field/types'
 import { toOpenAPIComponent, toOpenAPISchema } from '../openapi/generate'
-import type { OpenAPIUsage } from '../openapi/types'
+import type { OpenAPIUsage, WithOpenAPIOption } from '../openapi/types'
 import { createImpl, deleteImpl, findAllImpl, findManyImpl, findOneImpl, updateImpl } from './crud'
 import { applySchemaOptions, buildBaseObject, derivePolicyOptions } from './schema'
 import { buildTable } from './table'
@@ -113,8 +113,12 @@ export function defineModel<Fields extends Record<string, Field<any, any, any>>>
       return toOpenAPIComponent(fields)
     },
 
-    toOpenAPISchema(usage: OpenAPIUsage) {
-      return toOpenAPISchema(fields, usage)
+    toOpenAPISchema(usage: OpenAPIUsage, opts?: { readonly with: Partial<Record<string, true>> }) {
+      return toOpenAPISchema(
+        fields,
+        usage,
+        opts ? { with: opts.with as WithOpenAPIOption } : undefined,
+      )
     },
 
     findMany: ((adapter: Adapter, options: FindManyOptions<Fields>) =>

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -679,6 +679,10 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
 
   toOpenAPIComponent(): OpenAPIModelComponent
 
+  toOpenAPISchema(
+    usage: 'output',
+    opts: { readonly with: Partial<Record<RelationKeys<Fields> & string, true>> },
+  ): OpenAPISchemaObject
   toOpenAPISchema(usage: OpenAPIUsage): OpenAPISchemaObject
 
   /**

--- a/packages/nanoka/src/openapi/__tests__/openapi.test.ts
+++ b/packages/nanoka/src/openapi/__tests__/openapi.test.ts
@@ -214,3 +214,90 @@ describe('OpenAPI component generation', () => {
     expect(component.output.properties).toHaveProperty('name')
   })
 })
+
+describe('toOpenAPISchema with { with } option', () => {
+  const Post = defineModel('posts', {
+    id: t.integer().primary().readOnly(),
+    title: t.string(),
+    userId: t.integer(),
+  })
+
+  const User = defineModel('users', {
+    id: t.uuid().primary().readOnly(),
+    name: t.string(),
+    posts: t.hasMany(() => Post, { foreignKey: 'userId' }),
+  })
+
+  it('toOpenAPISchema("output") without with does not include relation', () => {
+    const schema = User.toOpenAPISchema('output')
+    expect(schema.properties).not.toHaveProperty('posts')
+  })
+
+  it('toOpenAPISchema("output", { with: { posts: true } }) expands hasMany as array', () => {
+    const schema = User.toOpenAPISchema('output', { with: { posts: true } })
+    const properties = schema.properties as Record<string, Record<string, unknown>>
+    expect(properties).toHaveProperty('posts')
+    const postsSchema = properties['posts']!
+    expect(postsSchema.type).toBe('array')
+    const items = postsSchema['items'] as Record<string, unknown>
+    expect(items.type).toBe('object')
+    const itemProperties = items['properties'] as Record<string, unknown>
+    expect(itemProperties).toHaveProperty('id')
+    expect(itemProperties).toHaveProperty('title')
+    expect(itemProperties).toHaveProperty('userId')
+  })
+
+  it('toOpenAPISchema("output", { with: { author: true } }) expands belongsTo as nullable object', () => {
+    const PostWithAuthor = defineModel('posts', {
+      id: t.integer().primary().readOnly(),
+      title: t.string(),
+      userId: t.integer(),
+      author: t.belongsTo(User, { foreignKey: 'userId' }),
+    })
+
+    const schema = PostWithAuthor.toOpenAPISchema('output', { with: { author: true } })
+    const properties = schema.properties as Record<string, Record<string, unknown>>
+    expect(properties).toHaveProperty('author')
+    const authorSchema = properties['author']!
+    expect(authorSchema.type).toBe('object')
+    expect(authorSchema.nullable).toBe(true)
+    const authorProperties = authorSchema['properties'] as Record<string, unknown>
+    expect(authorProperties).toHaveProperty('id')
+    expect(authorProperties).toHaveProperty('name')
+  })
+
+  it('toOpenAPISchema("create") with relation field does not include relation', () => {
+    const schema = User.toOpenAPISchema('create')
+    expect(schema.properties).not.toHaveProperty('posts')
+  })
+
+  it('create + with: { posts: true } does not expand relation', () => {
+    // usage が 'output' 以外の場合は with オプションを渡しても relation は展開されない
+    const schema = User.toOpenAPISchema('create' as any, { with: { posts: true } })
+    expect(schema.properties).not.toHaveProperty('posts')
+  })
+
+  it('does not recurse infinitely with bidirectional relations (depth 1 only)', () => {
+    const PostBi = defineModel('posts', {
+      id: t.integer().primary().readOnly(),
+      title: t.string(),
+      userId: t.uuid(),
+      author: t.belongsTo(User, { foreignKey: 'userId' }),
+    })
+
+    const UserBi = defineModel('users', {
+      id: t.uuid().primary().readOnly(),
+      name: t.string(),
+      posts: t.hasMany(() => PostBi, { foreignKey: 'userId' }),
+    })
+
+    expect(() => {
+      const schema = UserBi.toOpenAPISchema('output', { with: { posts: true } })
+      const properties = schema.properties as Record<string, Record<string, unknown>>
+      const postsSchema = properties['posts']!
+      const items = postsSchema['items'] as Record<string, unknown>
+      const itemProperties = items['properties'] as Record<string, unknown>
+      expect(itemProperties).not.toHaveProperty('author')
+    }).not.toThrow()
+  })
+})

--- a/packages/nanoka/src/openapi/generate.ts
+++ b/packages/nanoka/src/openapi/generate.ts
@@ -1,7 +1,12 @@
-import type { Field } from '../field/types'
+import type { Field, RelationDef } from '../field/types'
 import { applySchemaOptions, buildBaseObject, derivePolicyOptions } from '../model/schema'
 import type { SchemaOptions } from '../model/types'
-import type { OpenAPIModelComponent, OpenAPISchemaObject, OpenAPIUsage } from './types'
+import type {
+  OpenAPIModelComponent,
+  OpenAPISchemaObject,
+  OpenAPIUsage,
+  WithOpenAPIOption,
+} from './types'
 
 // biome-ignore lint/suspicious/noExplicitAny: OpenAPI generation accepts any concrete field builder.
 type AnyField = Field<any, any, any>
@@ -10,6 +15,7 @@ type FieldsRecord = Record<string, AnyField>
 interface OpenAPIOptions {
   readonly opts?: SchemaOptions
   readonly strict?: boolean
+  readonly with?: WithOpenAPIOption
 }
 
 export function toOpenAPIComponent(
@@ -50,6 +56,22 @@ export function toOpenAPISchema(
     }
     if (usage !== 'update' && isRequiredZodSchema(zodSchema)) {
       required.push(key)
+    }
+  }
+
+  if (usage === 'output' && opts?.with !== undefined) {
+    for (const [key, field] of Object.entries(fields)) {
+      if (field.kind !== 'relation') continue
+      if (opts.with[key] !== true) continue
+      const relationField = field as unknown as RelationDef
+      const rawTarget = relationField.target
+      const targetModel = typeof rawTarget === 'function' ? rawTarget() : rawTarget
+      const targetSchema = toOpenAPISchema(targetModel.fields as FieldsRecord, 'output')
+      if (relationField.relationKind === 'hasMany') {
+        properties[key] = { type: 'array', items: targetSchema }
+      } else {
+        properties[key] = { ...targetSchema, nullable: true }
+      }
     }
   }
 

--- a/packages/nanoka/src/openapi/index.ts
+++ b/packages/nanoka/src/openapi/index.ts
@@ -13,4 +13,5 @@ export type {
   OpenAPISpecOptions,
   OpenAPIUsage,
   RouteOpenAPIMetadata,
+  WithOpenAPIOption,
 } from './types'

--- a/packages/nanoka/src/openapi/types.ts
+++ b/packages/nanoka/src/openapi/types.ts
@@ -1,5 +1,7 @@
 export type OpenAPISchemaObject = Record<string, unknown>
 
+export type WithOpenAPIOption = Readonly<Record<string, true>>
+
 export interface OpenAPIModelComponent {
   create: OpenAPISchemaObject
   update: OpenAPISchemaObject

--- a/packages/nanoka/src/router/nanoka.ts
+++ b/packages/nanoka/src/router/nanoka.ts
@@ -118,7 +118,9 @@ export function nanoka<E extends Env = BlankEnv>(adapter: Adapter): Nanoka<E> {
 
       toOpenAPIComponent: () => inner.toOpenAPIComponent(),
 
-      toOpenAPISchema: (usage) => inner.toOpenAPISchema(usage),
+      toOpenAPISchema: (usage, opts?: { readonly with: Partial<Record<string, true>> }) =>
+        // biome-ignore lint/suspicious/noExplicitAny: NanokaModel interface overloads provide type safety
+        (inner.toOpenAPISchema as (u: typeof usage, o?: typeof opts) => any)(usage, opts),
 
       findMany: ((options: Parameters<NanokaModel<Fields>['findMany']>[0]) =>
         inner.findMany(adapter, options as any)) as NanokaModel<Fields>['findMany'],

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -16,6 +16,7 @@ import type {
   ModelValidatorReturn,
   NonRelationKeys,
   PolicyOmitKeys,
+  RelationKeys,
   RowType,
   SchemaOptions,
   ValidatorInput,
@@ -137,6 +138,10 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
 
   toOpenAPIComponent(): OpenAPIModelComponent
 
+  toOpenAPISchema(
+    usage: 'output',
+    opts: { readonly with: Partial<Record<RelationKeys<Fields> & string, true>> },
+  ): OpenAPISchemaObject
   toOpenAPISchema(usage: OpenAPIUsage): OpenAPISchemaObject
 
   /**


### PR DESCRIPTION
## Summary

- `toOpenAPISchema('output', { with: { posts: true } })` で relations を depth 1 で nested 展開できる opt-in オプションを追加
- `hasMany` → `{ type: 'array', items: <target output schema> }`、`belongsTo` → nullable object
- `outputSchema()` / `inputSchema()` / `validator()` の挙動は完全に不変（runtime validation source of truth は Zod のまま）
- `Model<Fields>` と `NanokaModel<Fields>` の両層を更新（two-layer split）
- `WithOpenAPIOption` 型を公開 API に追加
- version bump 1.8.1 → 1.9.0（minor）

## Changed files

- `packages/nanoka/src/openapi/types.ts` — `WithOpenAPIOption` 型追加
- `packages/nanoka/src/openapi/generate.ts` — `with` オプション対応
- `packages/nanoka/src/openapi/index.ts` — re-export
- `packages/nanoka/src/model/types.ts` — `toOpenAPISchema` オーバーロード追加
- `packages/nanoka/src/model/define.ts` — 引数転送
- `packages/nanoka/src/router/types.ts` — `NanokaModel` オーバーロード追加
- `packages/nanoka/src/router/nanoka.ts` — wire-up
- `packages/nanoka/src/openapi/__tests__/openapi.test.ts` — テスト追加
- `packages/nanoka/src/index.ts` — `WithOpenAPIOption` re-export
- `docs/nanoka.md` — Relations API 節の OpenAPI 制約記述を更新
- `docs/implementation-status.md` — #91 完了エントリ追加

## Test plan

- [x] `toOpenAPISchema('output', { with: { posts: true } })` が nested array を返す
- [x] `toOpenAPISchema('output')` (with なし) の出力が既存スナップショットと完全一致（後方互換）
- [x] `belongsTo` で nullable object になる
- [x] `usage: 'create' + with` を渡しても relation が展開されない
- [x] 双方向 relation での無限再帰なし（depth 1 のみ）
- [x] 438 tests passed, typecheck pass, lint errors 0

Closes #91
Parent: #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)