### PR TITLE
feat(@nanokajs/auth): add Hasher interface and pbkdf2Hasher implementation

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -71,6 +71,10 @@
 
 Auth（コアに含めない）/ full-stack React / Drizzle replacement DSL は実装しない。Auth は `@nanokajs/auth` パッケージとして別途提供（パッケージ骨格は v1.9.0 で追加済み — Issue #74 / #75）。
 
+`@nanokajs/auth` shipped:
+- `Hasher` インターフェース（`hash` / `verify`）— Issue #76
+- `pbkdf2Hasher`: `crypto.subtle` のみを使う zero-dependency PBKDF2 実装（SHA-256、310,000 iterations、タイミングセーフ比較）— Issue #76
+
 ### Typed query helper を non-goal とする根拠
 
 - `findOne` / `update` / `delete` は既に `Where<Fields>`（等価 AND）を受け付けており、単純なルックアップは shipped

--- a/packages/nanoka-auth/package.json
+++ b/packages/nanoka-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/auth",
-  "version": "1.9.0",
+  "version": "1.0.0",
   "type": "module",
   "description": "Authentication utilities for Nanoka on Cloudflare Workers.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",
@@ -42,14 +42,19 @@
   },
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit"
-  },
-  "peerDependencies": {
-    "@nanokajs/core": "^1.9.0"
+    "test": "vitest run -c vitest.config.ts && vitest run -c vitest.node.config.ts",
+    "test:workers": "vitest run -c vitest.config.ts",
+    "test:node": "vitest run -c vitest.node.config.ts",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm build && pnpm test && pnpm typecheck"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "@cloudflare/workers-types": "^4.20240925.0",
     "@types/node": "^25.6.0",
     "tsup": "^8.3.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0",
+    "wrangler": "^3.80.0"
   }
 }

--- a/packages/nanoka-auth/src/hasher.ts
+++ b/packages/nanoka-auth/src/hasher.ts
@@ -1,0 +1,4 @@
+export interface Hasher {
+  hash(plain: string): Promise<string>
+  verify(plain: string, stored: string): Promise<boolean>
+}

--- a/packages/nanoka-auth/src/hashers/__tests__/pbkdf2.test.ts
+++ b/packages/nanoka-auth/src/hashers/__tests__/pbkdf2.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { pbkdf2Hasher } from '../pbkdf2.js'
+
+describe('pbkdf2Hasher', () => {
+  it('hash outputs $pbkdf2$310000$<salt>$<hash> format', async () => {
+    const hashed = await pbkdf2Hasher.hash('password')
+    const parts = hashed.split('$')
+    expect(parts).toHaveLength(5)
+    expect(parts[0]).toBe('')
+    expect(parts[1]).toBe('pbkdf2')
+    expect(parts[2]).toBe('310000')
+    expect((parts[3] as string).length).toBeGreaterThan(0)
+    expect((parts[4] as string).length).toBeGreaterThan(0)
+  })
+
+  it('hash → verify round-trip returns true', async () => {
+    const hashed = await pbkdf2Hasher.hash('my-secret')
+    const result = await pbkdf2Hasher.verify('my-secret', hashed)
+    expect(result).toBe(true)
+  })
+
+  it('verify returns false for a different password', async () => {
+    const hashed = await pbkdf2Hasher.hash('correct-password')
+    const result = await pbkdf2Hasher.verify('wrong-password', hashed)
+    expect(result).toBe(false)
+  })
+
+  it('hashing the same input twice produces different outputs (salt randomness)', async () => {
+    const hash1 = await pbkdf2Hasher.hash('same-input')
+    const hash2 = await pbkdf2Hasher.hash('same-input')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('verify returns false for invalid formats', async () => {
+    expect(await pbkdf2Hasher.verify('password', 'not-a-hash')).toBe(false)
+    expect(await pbkdf2Hasher.verify('password', '')).toBe(false)
+    expect(await pbkdf2Hasher.verify('password', '$bcrypt$12$somesalt$somehash')).toBe(false)
+  })
+
+  it('verify returns false for malformed base64 in stored value', async () => {
+    expect(await pbkdf2Hasher.verify('password', '$pbkdf2$310000$!!!notb64!!!$!!!')).toBe(false)
+  })
+
+  it('verify returns false for excessively large iterations (DoS guard)', async () => {
+    expect(await pbkdf2Hasher.verify('password', '$pbkdf2$999999999$somesalt$somehash')).toBe(false)
+  })
+})

--- a/packages/nanoka-auth/src/hashers/pbkdf2.ts
+++ b/packages/nanoka-auth/src/hashers/pbkdf2.ts
@@ -1,0 +1,94 @@
+import type { Hasher } from '../hasher.js'
+
+const ITERATIONS = 310_000
+const SALT_BYTES = 16
+const HASH_BYTES = 32
+const HASH_NAME = 'SHA-256'
+
+function utf8(str: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(str) as unknown as Uint8Array<ArrayBuffer>
+}
+
+function toBase64url(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i] as number)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function fromBase64url(str: string): Uint8Array<ArrayBuffer> | null {
+  try {
+    const padded = str
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(str.length + ((4 - (str.length % 4)) % 4), '=')
+    const binary = atob(padded)
+    const buf = new ArrayBuffer(binary.length)
+    const bytes = new Uint8Array(buf)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes
+  } catch {
+    return null
+  }
+}
+
+async function derive(
+  plain: string,
+  salt: Uint8Array<ArrayBuffer>,
+  iterations: number,
+): Promise<ArrayBuffer> {
+  const key = await crypto.subtle.importKey('raw', utf8(plain), 'PBKDF2', false, ['deriveBits'])
+  return crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt, iterations, hash: HASH_NAME },
+    key,
+    HASH_BYTES * 8,
+  )
+}
+
+function timingSafeEqual(a: Uint8Array<ArrayBuffer>, b: Uint8Array<ArrayBuffer>): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= (a[i] as number) ^ (b[i] as number)
+  }
+  return diff === 0
+}
+
+export const pbkdf2Hasher: Hasher = {
+  async hash(plain: string): Promise<string> {
+    const saltBuf = new ArrayBuffer(SALT_BYTES)
+    const salt = new Uint8Array(saltBuf) as Uint8Array<ArrayBuffer>
+    crypto.getRandomValues(salt)
+    const derived = await derive(plain, salt, ITERATIONS)
+    return `$pbkdf2$${ITERATIONS}$${toBase64url(saltBuf)}$${toBase64url(derived)}`
+  },
+
+  async verify(plain: string, stored: string): Promise<boolean> {
+    const parts = stored.split('$')
+    if (parts.length !== 5 || parts[0] !== '') return false
+    const algoId = parts[1]
+    const iterStr = parts[2]
+    const saltB64 = parts[3]
+    const hashB64 = parts[4]
+    if (algoId !== 'pbkdf2') return false
+    if (iterStr === undefined || saltB64 === undefined || hashB64 === undefined) return false
+
+    const iterations = Number.parseInt(iterStr, 10)
+    if (!Number.isFinite(iterations) || iterations <= 0 || iterations > 1_000_000) return false
+
+    const salt = fromBase64url(saltB64)
+    const storedHash = fromBase64url(hashB64)
+
+    if (salt === null || storedHash === null) return false
+    if (salt.length === 0 || storedHash.length !== HASH_BYTES) return false
+
+    const derived = await derive(plain, salt, iterations)
+    const derivedBytes = new Uint8Array(derived) as Uint8Array<ArrayBuffer>
+
+    return timingSafeEqual(derivedBytes, storedHash)
+  },
+}

--- a/packages/nanoka-auth/src/index.ts
+++ b/packages/nanoka-auth/src/index.ts
@@ -1,1 +1,2 @@
-export {}
+export type { Hasher } from './hasher.js'
+export { pbkdf2Hasher } from './hashers/pbkdf2.js'

--- a/packages/nanoka-auth/vitest.config.ts
+++ b/packages/nanoka-auth/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
+
+export default defineWorkersConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts'],
+    poolOptions: {
+      workers: {
+        miniflare: {
+          compatibilityDate: '2025-04-01',
+          compatibilityFlags: ['nodejs_compat'],
+        },
+      },
+    },
+  },
+})

--- a/packages/nanoka-auth/vitest.node.config.ts
+++ b/packages/nanoka-auth/vitest.node.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0))(hono@4.12.16)(zod@3.25.76)
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.5.0
+        version: 0.5.41(@cloudflare/workers-types@4.20260501.1)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@25.6.0))
+      '@cloudflare/workers-types':
+        specifier: ^4.20240925.0
+        version: 4.20260501.1
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -127,6 +133,12 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@25.6.0)
+      wrangler:
+        specifier: '>=3.114.17 <4.0.0'
+        version: 3.114.17(@cloudflare/workers-types@4.20260501.1)
 
   site:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,10 +113,6 @@ importers:
         version: 3.25.76
 
   packages/nanoka-auth:
-    dependencies:
-      '@nanokajs/core':
-        specifier: ^1.9.0
-        version: 1.9.0(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0))(hono@4.12.16)(zod@3.25.76)
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.5.0
@@ -1354,20 +1350,6 @@ packages:
     resolution: {integrity: sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw==}
     cpu: [x64]
     os: [win32]
-
-  '@nanokajs/core@1.9.0':
-    resolution: {integrity: sha512-flI3ImCdfCoF8J6eagiOi+gH5xYEmtGkVwQ3IHgKjD/fV/cCBW9hzhVaznZ6OZBKVwt8g+HuZC+sR/mu0Z939g==}
-    engines: {node: '>=20'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.20240925.0
-      '@libsql/client': ^0.14.0
-      drizzle-orm: ^0.45.2
-      hono: ^4.0.0
-      zod: ^3.23.0 || ^4.0.0
-    peerDependenciesMeta:
-      '@libsql/client':
-        optional: true
 
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
@@ -3093,17 +3075,6 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.4.7':
     optional: true
-
-  '@nanokajs/core@1.9.0(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0))(hono@4.12.16)(zod@3.25.76)':
-    dependencies:
-      '@cloudflare/workers-types': 4.20260501.1
-      '@hono/zod-validator': 0.4.3(hono@4.12.16)(zod@3.25.76)
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260501.1)(@libsql/client@0.14.0)
-      hono: 4.12.16
-      jiti: 2.6.1
-      zod: 3.25.76
-    optionalDependencies:
-      '@libsql/client': 0.14.0
 
   '@neon-rs/load@0.0.4': {}
 


### PR DESCRIPTION
## Summary

- `Hasher` インターフェース（`hash` / `verify`）を `@nanokajs/auth` からエクスポート
- `pbkdf2Hasher` を追加（`crypto.subtle` のみ使用、zero-dependency）
  - PBKDF2-SHA-256、310,000 iterations、16-byte salt（NIST SP 800-132 準拠）
  - 出力フォーマット: `$pbkdf2$<iter>$<base64url(salt)>$<base64url(derived)>`
  - タイミングセーフ比較（XOR 合計方式）
  - iterations 上限チェック（>1,000,000 で `false`）で DoS 耐性を確保
  - 不正 base64 でも throw せず `false` を返す
- Workers / Node.js 両環境でテストが通ること（各 7 ケース）を確認
- `package.json` の `peerDependencies` から未使用の `@nanokajs/core` を削除
- `@nanokajs/auth` バージョンを `1.0.0` に設定（初回 publish 前のため）

## Test plan

- [x] `pnpm -C packages/nanoka-auth test:workers` — 7 tests passed（Miniflare / Workers 環境）
- [x] `pnpm -C packages/nanoka-auth test:node` — 7 tests passed（Node 20 環境）
- [x] `pnpm -C packages/nanoka-auth typecheck` — pass
- [x] `pnpm -C packages/nanoka-auth build` — pass
- [x] `pnpm lint` — no errors

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)