### PR TITLE
fix(lint): resolve biome warnings that required no design judgment

### DIFF
--- a/packages/nanoka/src/field/factories.ts
+++ b/packages/nanoka/src/field/factories.ts
@@ -984,7 +984,6 @@ export class RelationFieldBuilder<
   readonly target: Target | (() => Target)
   readonly foreignKey: FK
   readonly tsType!: never
-  // biome-ignore lint/complexity/noBannedTypes: {} is used intentionally for empty modifiers
   readonly modifiers = {} as const
 
   constructor(relationKind: Kind, target: Target | (() => Target), foreignKey: FK) {

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -147,8 +147,8 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       })
 
       expect(rows.length).toBe(2)
-      expect(rows[0]!.id).toBe('uuid-4b')
-      expect(rows[1]!.id).toBe('uuid-4c')
+      expect(rows[0]?.id).toBe('uuid-4b')
+      expect(rows[1]?.id).toBe('uuid-4c')
     })
 
     it('5. findMany with orderBy as object with desc direction', async () => {
@@ -164,8 +164,8 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       })
 
       expect(rows.length).toBe(2)
-      expect(rows[0]!.name).toBe('Y')
-      expect(rows[1]!.name).toBe('X')
+      expect(rows[0]?.name).toBe('Y')
+      expect(rows[1]?.name).toBe('X')
     })
 
     it('6. findMany with multiple orderBy columns', async () => {
@@ -181,8 +181,8 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       })
 
       expect(rows.length).toBe(2)
-      expect(rows[0]!.name).toBe('A')
-      expect(rows[1]!.name).toBe('B')
+      expect(rows[0]?.name).toBe('A')
+      expect(rows[1]?.name).toBe('B')
     })
 
     it('7. update with PK and return updated row', async () => {
@@ -246,6 +246,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       const { env } = await import('cloudflare:test')
       const adapter = d1Adapter(env.DB)
 
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       await expect(User.findMany(adapter, { limit: -1 } as any)).rejects.toThrow(HTTPException)
     })
 
@@ -253,6 +254,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       const { env } = await import('cloudflare:test')
       const adapter = d1Adapter(env.DB)
 
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       await expect(User.findMany(adapter, { limit: NaN } as any)).rejects.toThrow(HTTPException)
     })
 
@@ -270,6 +272,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       const { env } = await import('cloudflare:test')
       const adapter = d1Adapter(env.DB)
 
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       await expect(User.delete(adapter, {} as any)).rejects.toThrow(HTTPException)
     })
 
@@ -280,6 +283,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       await User.create(adapter, { id: 'uuid-14', name: 'Test', email: 'test@example.com' })
 
       await expect(
+        // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
         User.findMany(adapter, { limit: 20, orderBy: 'evil; drop' as any } as any),
       ).rejects.toThrow(HTTPException)
     })
@@ -290,6 +294,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
 
       // Simulate untrusted input that has a prototype-chain key as own property
       const malicious = JSON.parse('{"toString": "x"}')
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       await expect(User.findOne(adapter, malicious as any)).rejects.toThrow(HTTPException)
     })
 
@@ -300,6 +305,7 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
       await User.create(adapter, { id: 'uuid-16', name: 'Test', email: 'test@example.com' })
 
       await expect(
+        // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
         User.findMany(adapter, { limit: 20, orderBy: 'toString' as any } as any),
       ).rejects.toThrow(HTTPException)
     })
@@ -361,7 +367,7 @@ describe('findMany SQL where + toResponseMany', () => {
     })
 
     expect(rows.length).toBe(1)
-    expect(rows[0]!.name).toBe('Alice')
+    expect(rows[0]?.name).toBe('Alice')
   })
 
   it('where: like() fetches multiple matching rows', async () => {
@@ -410,19 +416,20 @@ describe('findMany SQL where + toResponseMany', () => {
     // Insert directly via escape hatch because serverOnly fields are excluded from CreateInput
     await adapter.drizzle
       .insert(SecureUser.table)
-      // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
       .values([
         {
           id: '11111111-1111-1111-1111-111111111111',
           name: 'Heidi',
           email: 'heidi@example.com',
           passwordHash: 'secret9',
+        // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
         } as any,
         {
           id: '22222222-2222-2222-2222-222222222222',
           name: 'Ivan',
           email: 'ivan@example.com',
           passwordHash: 'secret10',
+        // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
         } as any,
       ])
       .run()
@@ -581,8 +588,8 @@ describe('relation eager loading', () => {
     })
 
     expect(users).toHaveLength(2)
-    expect(users[0]!.posts.map((post) => post.id)).toEqual(['rp-1', 'rp-2'])
-    expect(users[1]!.posts.map((post) => post.id)).toEqual(['rp-3'])
+    expect(users[0]?.posts.map((post) => post.id)).toEqual(['rp-1', 'rp-2'])
+    expect(users[1]?.posts.map((post) => post.id)).toEqual(['rp-3'])
   })
 
   it('findOne loads hasMany rows', async () => {
@@ -605,9 +612,9 @@ describe('relation eager loading', () => {
       with: { author: true },
     })
 
-    expect(posts[0]!.author?.id).toBe('ra-1')
-    expect(posts[1]!.author?.id).toBe('ra-2')
-    expect(posts[2]!.author).toBeNull()
+    expect(posts[0]?.author?.id).toBe('ra-1')
+    expect(posts[1]?.author?.id).toBe('ra-2')
+    expect(posts[2]?.author).toBeNull()
   })
 
   it('combines where, orderBy, offset, and with on the parent query', async () => {
@@ -623,8 +630,8 @@ describe('relation eager loading', () => {
     })
 
     expect(users).toHaveLength(1)
-    expect(users[0]!.id).toBe('ru-2')
-    expect(users[0]!.posts.map((post) => post.id)).toEqual(['rp-3'])
+    expect(users[0]?.id).toBe('ru-2')
+    expect(users[0]?.posts.map((post) => post.id)).toEqual(['rp-3'])
   })
 
   it('returns an empty parent result without relation rows', async () => {
@@ -648,6 +655,7 @@ describe('relation eager loading', () => {
       RelationUser.findMany(adapter, {
         limit: 10,
         with: { posts: { with: { comments: true } } },
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       } as any),
     ).rejects.toThrow(HTTPException)
   })
@@ -657,6 +665,7 @@ describe('relation eager loading', () => {
     const adapter = d1Adapter(env.DB)
 
     await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       RelationUser.findMany(adapter, { limit: 10, with: { name: true } } as any),
     ).rejects.toThrow(HTTPException)
   })
@@ -665,10 +674,12 @@ describe('relation eager loading', () => {
     const { env } = await import('cloudflare:test')
     const adapter = d1Adapter(env.DB)
 
+    // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
     await expect(RelationUser.findMany(adapter, { limit: 10, with: null } as any)).rejects.toThrow(
       HTTPException,
     )
     await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       RelationUser.findMany(adapter, { limit: 10, with: ['posts'] } as any),
     ).rejects.toThrow(HTTPException)
   })
@@ -683,7 +694,7 @@ describe('relation eager loading', () => {
     })
 
     expect(users).toHaveLength(1)
-    expect(users[0]!.posts.map((post: { id: string }) => post.id)).toEqual(['cp-1'])
+    expect(users[0]?.posts.map((post: { id: string }) => post.id)).toEqual(['cp-1'])
   })
 
   it('allows depth-1 belongsTo loading on bidirectional relation graphs', async () => {
@@ -696,7 +707,7 @@ describe('relation eager loading', () => {
     })
 
     expect(posts).toHaveLength(1)
-    expect(posts[0]!.user?.id).toBe('cu-1')
+    expect(posts[0]?.user?.id).toBe('cu-1')
   })
 
   it('returns null for findOne with missing parent row and with option', async () => {
@@ -715,9 +726,11 @@ describe('relation eager loading', () => {
     await expect(
       CycleUser.findOne(adapter, 'missing-user', {
         with: { posts: { with: { user: true } } },
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       } as any),
     ).rejects.toThrow(HTTPException)
     await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       CycleUser.findOne(adapter, 'missing-user', { with: { name: true } } as any),
     ).rejects.toThrow(HTTPException)
   })
@@ -772,8 +785,8 @@ describe('findAll', () => {
 
     const rows = await AllUser.findAll(adapter, { offset: 1, orderBy: 'id' })
     expect(rows.length).toBe(2)
-    expect(rows[0]!.id).toBe('all-2')
-    expect(rows[1]!.id).toBe('all-3')
+    expect(rows[0]?.id).toBe('all-2')
+    expect(rows[1]?.id).toBe('all-3')
   })
 
   it('orderBy asc sorts correctly', async () => {
@@ -808,7 +821,7 @@ describe('findAll', () => {
 
     const rows = await AllUser.findAll(adapter, { where: { email: 'alice@example.com' } })
     expect(rows.length).toBe(1)
-    expect(rows[0]!.name).toBe('Alice')
+    expect(rows[0]?.name).toBe('Alice')
   })
 
   it('where Drizzle SQL expression (like) filters rows', async () => {

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -422,14 +422,14 @@ describe('findMany SQL where + toResponseMany', () => {
           name: 'Heidi',
           email: 'heidi@example.com',
           passwordHash: 'secret9',
-        // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
+          // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
         } as any,
         {
           id: '22222222-2222-2222-2222-222222222222',
           name: 'Ivan',
           email: 'ivan@example.com',
           passwordHash: 'secret10',
-        // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
+          // biome-ignore lint/suspicious/noExplicitAny: inserting serverOnly field directly via escape hatch
         } as any,
       ])
       .run()
@@ -655,7 +655,7 @@ describe('relation eager loading', () => {
       RelationUser.findMany(adapter, {
         limit: 10,
         with: { posts: { with: { comments: true } } },
-      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
+        // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       } as any),
     ).rejects.toThrow(HTTPException)
   })
@@ -726,7 +726,7 @@ describe('relation eager loading', () => {
     await expect(
       CycleUser.findOne(adapter, 'missing-user', {
         with: { posts: { with: { user: true } } },
-      // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
+        // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
       } as any),
     ).rejects.toThrow(HTTPException)
     await expect(

--- a/packages/nanoka/src/openapi/__tests__/openapi.test.ts
+++ b/packages/nanoka/src/openapi/__tests__/openapi.test.ts
@@ -237,11 +237,11 @@ describe('toOpenAPISchema with { with } option', () => {
     const schema = User.toOpenAPISchema('output', { with: { posts: true } })
     const properties = schema.properties as Record<string, Record<string, unknown>>
     expect(properties).toHaveProperty('posts')
-    const postsSchema = properties['posts']!
-    expect(postsSchema.type).toBe('array')
-    const items = postsSchema['items'] as Record<string, unknown>
+    const postsSchema = properties.posts
+    expect(postsSchema?.type).toBe('array')
+    const items = postsSchema?.items as Record<string, unknown>
     expect(items.type).toBe('object')
-    const itemProperties = items['properties'] as Record<string, unknown>
+    const itemProperties = items.properties as Record<string, unknown>
     expect(itemProperties).toHaveProperty('id')
     expect(itemProperties).toHaveProperty('title')
     expect(itemProperties).toHaveProperty('userId')
@@ -258,10 +258,10 @@ describe('toOpenAPISchema with { with } option', () => {
     const schema = PostWithAuthor.toOpenAPISchema('output', { with: { author: true } })
     const properties = schema.properties as Record<string, Record<string, unknown>>
     expect(properties).toHaveProperty('author')
-    const authorSchema = properties['author']!
-    expect(authorSchema.type).toBe('object')
-    expect(authorSchema.nullable).toBe(true)
-    const authorProperties = authorSchema['properties'] as Record<string, unknown>
+    const authorSchema = properties.author
+    expect(authorSchema?.type).toBe('object')
+    expect(authorSchema?.nullable).toBe(true)
+    const authorProperties = authorSchema?.properties as Record<string, unknown>
     expect(authorProperties).toHaveProperty('id')
     expect(authorProperties).toHaveProperty('name')
   })
@@ -273,6 +273,7 @@ describe('toOpenAPISchema with { with } option', () => {
 
   it('create + with: { posts: true } does not expand relation', () => {
     // usage が 'output' 以外の場合は with オプションを渡しても relation は展開されない
+    // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime behaviour
     const schema = User.toOpenAPISchema('create' as any, { with: { posts: true } })
     expect(schema.properties).not.toHaveProperty('posts')
   })
@@ -294,9 +295,9 @@ describe('toOpenAPISchema with { with } option', () => {
     expect(() => {
       const schema = UserBi.toOpenAPISchema('output', { with: { posts: true } })
       const properties = schema.properties as Record<string, Record<string, unknown>>
-      const postsSchema = properties['posts']!
-      const items = postsSchema['items'] as Record<string, unknown>
-      const itemProperties = items['properties'] as Record<string, unknown>
+      const postsSchema = properties.posts
+      const items = postsSchema?.items as Record<string, unknown>
+      const itemProperties = items.properties as Record<string, unknown>
       expect(itemProperties).not.toHaveProperty('author')
     }).not.toThrow()
   })

--- a/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
@@ -136,11 +136,14 @@ describe('nanoka() integration with D1', () => {
       // Access raw Drizzle via app.db escape hatch
       const rawResult = await app.db
         .select()
+        // biome-ignore lint/suspicious/noExplicitAny: accessing Drizzle escape hatch with raw table type
         .from(User.table as any)
+        // biome-ignore lint/suspicious/noExplicitAny: accessing Drizzle escape hatch with raw table type
         .where(eq((User.table as any).id, userId))
         .limit(1)
 
       expect(rawResult).toHaveLength(1)
+      // biome-ignore lint/suspicious/noExplicitAny: accessing raw Drizzle result without schema type
       expect((rawResult[0] as any).name).toBe('Test User')
     })
   })
@@ -172,6 +175,7 @@ describe('nanoka() integration with D1', () => {
         passwordHash: 'hashed2',
       })
 
+      // biome-ignore lint/suspicious/noExplicitAny: batch API type requires cast for mixed query types
       const results = await app.batch([query1, query2] as any)
 
       expect(results).toHaveLength(2)
@@ -356,7 +360,7 @@ describe('nanoka() integration with D1', () => {
       const users = await User.findMany({ limit: 10, with: { posts: true } })
 
       expect(users).toHaveLength(1)
-      expect(users[0]!.posts.map((post) => post.id)).toEqual(['rrp-1'])
+      expect(users[0]?.posts.map((post) => post.id)).toEqual(['rrp-1'])
     })
 
     it('findOne loads belongsTo relations from adapter-bound API', async () => {
@@ -396,6 +400,7 @@ describe('nanoka() integration with D1', () => {
         passwordHash: t.string(),
       })
 
+      // biome-ignore lint/suspicious/noExplicitAny: test variable to capture validated body
       let receivedBody: any
 
       app.post('/users-safe', User.validator('json', { omit: ['passwordHash'] }), (c) => {
@@ -431,6 +436,7 @@ describe('nanoka() integration with D1', () => {
         passwordHash: t.string(),
       })
 
+      // biome-ignore lint/suspicious/noExplicitAny: test variable to capture validated body
       let receivedBody: any
 
       app.patch(


### PR DESCRIPTION
## Summary

- `factories.ts` の unused suppression コメントを削除（オブジェクトリテラル `{}` は `noBannedTypes` 対象外）
- テストファイルの `noNonNullAssertion`：`!` を `?.` に置き換え
- `biome-ignore` コメントを `as any` が含まれる行の直前に移動（多行式では先頭行に置いても suppression が無効になるため）
- 意図的な `as any`（ランタイムバリデーションテスト、escape-hatch insert、raw Drizzle アクセス）に `biome-ignore` コメントを追加
- `openapi.test.ts` の `useLiteralKeys` を auto-fix で修正

## 対象外（判断が必要なため別 Issue）

`crud.ts` / `table.ts` / `types.ts` / `nanoka.ts` / `router/types.ts` の `noExplicitAny` は Drizzle 型システムとの境界部分であり、型レベルの設計判断が必要なため今回は含まない。

## Test plan

- [ ] `pnpm -C packages/nanoka test:workers` — 406 tests passed
- [ ] `pnpm lint` — 残存 warning は設計判断が必要な内部実装ファイルのみ（テストファイルの warning はゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)