### PR TITLE
feat(crud): add MAX_OFFSET runtime cap to findMany (#18)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -38,6 +38,7 @@
 - `Model.toResponseMany(rows)` ヘルパ — [#39](https://github.com/nanokajs/nanoka/issues/39)
 - `Model.findAll(adapter, options?)` — LIMIT なし全件取得。`findMany` の `MAX_LIMIT = 100` ランタイムキャップを廃止 — [#49](https://github.com/nanokajs/nanoka/issues/49)
 - `toOpenAPISchema('output', { with })` による relations nested 展開（spec-only、runtime は Zod のまま） — [#91](https://github.com/nanokajs/nanoka/issues/91)
+- `findMany` の `offset` runtime cap = 100_000 — [#18](https://github.com/nanokajs/nanoka/issues/18)
 
 ### AI coding support
 
@@ -52,10 +53,6 @@
 - コンテンツ執筆（Introduction / Getting Started / Core Concepts）+ 言語トグル機構（EN/JA） — [#60](https://github.com/nanokajs/nanoka/issues/60)
 - API Reference コンテンツ執筆（Field Types / Field Policies / Schema & Validator / CRUD Methods / Response Shaping / OpenAPI / Escape Hatch / Adapters） — [#61](https://github.com/nanokajs/nanoka/issues/61)
 - Guides / CLI Reference コンテンツ執筆（Migration Workflow / Error Handling / Using with Turso / CLI Reference） — [#62](https://github.com/nanokajs/nanoka/issues/62)
-
-## 未実装として残す（将来候補）
-
-- `findMany` offset 上限 — [#18](https://github.com/nanokajs/nanoka/issues/18)
 
 ## 実装中（設計確定済み）
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -240,6 +240,8 @@ Calling `findMany()` without `limit` is a **type error** — the parameter is re
 
 Pagination shape: `{ limit, offset?, orderBy?, where? }`. The `where` field accepts either an equality object or any Drizzle `SQL` expression. Never pass user input to `sql.raw()` — use parametrized Drizzle operators instead.
 
+**Offset cap**: `offset` is capped at 100_000 to prevent read amplification. If you need to paginate deeper, use cursor-based pagination (e.g., `id > lastId`) instead of offset/limit.
+
 **`findAll(options?)`** — fetch all rows without LIMIT
 
 ```ts

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -334,6 +334,8 @@ const specific = await User.findMany({
 
 When passing a Drizzle SQL expression, SQL injection prevention follows Drizzle's parametrized binding rules — ensure all user-supplied values are passed as Drizzle operands (e.g., `like(col, value)`) rather than interpolated into raw strings. Never pass user input to `sql.raw()`, which skips parametrization entirely.
 
+**`offset` runtime cap:** `offset` is capped at 100,000 to prevent read amplification and DoS. If you need to paginate deeper, use cursor pagination (e.g., `id > lastId`) instead of offset/limit.
+
 ### `findAll` — unbounded fetch (no LIMIT)
 
 `findAll` issues no LIMIT clause and returns every row. Use it for batch processing, admin tooling, or export pipelines where you intentionally want all records.

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -309,6 +309,43 @@ describe('CRUD operations: vitest-pool-workers D1 integration', () => {
         User.findMany(adapter, { limit: 20, orderBy: 'toString' as any } as any),
       ).rejects.toThrow(HTTPException)
     })
+
+    it('17. reject offset > MAX_OFFSET (100_000)', async () => {
+      const { env } = await import('cloudflare:test')
+      const adapter = d1Adapter(env.DB)
+
+      await expect(User.findMany(adapter, { limit: 20, offset: 100_001 })).rejects.toThrow(
+        HTTPException,
+      )
+    })
+
+    it('18. accept offset === MAX_OFFSET (boundary)', async () => {
+      const { env } = await import('cloudflare:test')
+      const adapter = d1Adapter(env.DB)
+
+      await User.create(adapter, { id: 'uuid-18', name: 'Boundary', email: 'boundary@example.com' })
+
+      // Should not throw even though offset equals MAX_OFFSET
+      const rows = await User.findMany(adapter, { limit: 20, offset: 100_000 })
+      expect(Array.isArray(rows)).toBe(true)
+    })
+  })
+
+  describe('findAll', () => {
+    it('findAll allows offset > MAX_OFFSET (no cap)', async () => {
+      const { env } = await import('cloudflare:test')
+      const adapter = d1Adapter(env.DB)
+
+      await User.create(adapter, {
+        id: 'uuid-findall',
+        name: 'FindAll',
+        email: 'findall@example.com',
+      })
+
+      // findAll should not reject offset > MAX_OFFSET
+      const rows = await User.findAll(adapter, { offset: 100_001 })
+      expect(Array.isArray(rows)).toBe(true)
+    })
   })
 })
 

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -16,6 +16,9 @@ import type {
   WithResult,
 } from './types'
 
+// DoS guard for findMany; findAll intentionally bypasses this; values >100k → use cursor pagination. Keep in sync with README / docs-site / llms-full.txt.
+const MAX_OFFSET = 100_000
+
 /**
  * Validates and guards limit/offset parameters.
  * @internal
@@ -277,6 +280,12 @@ export async function findManyImpl<
 ): Promise<RowType<Fields>[] | WithResult<Fields, NonNullable<With>>[]> {
   const limit = guardLimit(options.limit)
   const offset = options.offset !== undefined ? guardOffset(options.offset) : 0
+
+  if (offset > MAX_OFFSET) {
+    throw new HTTPException(400, {
+      message: `offset must be <= ${MAX_OFFSET}; use cursor pagination for deeper paging`,
+    })
+  }
 
   // biome-ignore lint/suspicious/noExplicitAny: drizzle query builder type narrowing
   let query: any = adapter.drizzle.select().from(table).limit(limit).offset(offset)

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -57,7 +57,7 @@ export type WithResult<
 /**
  * Options for findMany query.
  * `limit` is required (no default).
- * `offset` defaults to 0 if omitted.
+ * `offset` defaults to 0 if omitted. Runtime-capped at 100_000 to prevent read amplification — use cursor pagination for deeper paging.
  * `orderBy` is optional for column ordering.
  * `where` accepts either an equality object or a Drizzle SQL expression.
  */
@@ -67,6 +67,7 @@ export interface FindManyOptions<
   With extends WithOptions<Fields> | undefined = undefined,
 > {
   readonly limit: number
+  /** default: 0; runtime cap: 100000 */
   readonly offset?: number
   readonly orderBy?: OrderBy<Fields>
   readonly where?: Where<Fields> | SQL
@@ -688,7 +689,7 @@ export interface Model<Fields extends Record<string, Field<any, any, any>>> {
   /**
    * Fetches multiple rows with pagination and optional ordering.
    * `limit` is required (no default) to prevent accidental unbounded queries.
-   * Offset defaults to 0 if omitted.
+   * Offset defaults to 0 if omitted. Runtime-capped at offset 100_000 — use cursor pagination for deeper paging.
    *
    * @example
    * const users = await User.findMany(adapter, { limit: 20 })

--- a/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
+++ b/packages/nanoka/src/router/__tests__/nanoka.integration.test.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { eq, sql } from 'drizzle-orm'
+import { HTTPException } from 'hono/http-exception'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { d1Adapter } from '../../adapter'
 import { t } from '../../field'
@@ -460,6 +461,23 @@ describe('nanoka() integration with D1', () => {
       const response = await app.fetch(request)
       expect(response.status).toBe(200)
       expect(receivedBody).toEqual({ name: 'Partial Update' })
+    })
+  })
+
+  describe('MAX_OFFSET cap on findMany', () => {
+    it('findMany rejects offset > MAX_OFFSET via app.model() binding', async () => {
+      const { env } = await import('cloudflare:test')
+      const app = nanoka(d1Adapter(env.DB))
+
+      const User = app.model('users', {
+        id: t.uuid().primary(),
+        name: t.string(),
+        email: t.string().email(),
+        passwordHash: t.string(),
+      })
+
+      // findMany called through app.model() should reject offset > 100_000
+      await expect(User.findMany({ limit: 20, offset: 100_001 })).rejects.toThrow(HTTPException)
     })
   })
 })

--- a/packages/nanoka/src/router/types.ts
+++ b/packages/nanoka/src/router/types.ts
@@ -147,6 +147,7 @@ export interface NanokaModel<Fields extends Record<string, Field<any, any, any>>
   /**
    * Fetches multiple rows with pagination and optional ordering.
    * `limit` is required (no default) to prevent accidental unbounded queries.
+   * Runtime-capped at offset 100_000 — use cursor pagination for deeper paging.
    */
   findMany<With extends WithOptions<Fields>>(
     options: FindManyOptions<Fields, With> & { readonly with: With },

--- a/site/src/content/api/crud.ts
+++ b/site/src/content/api/crud.ts
@@ -22,7 +22,7 @@ const page2 = await User.findMany({ limit: 20, offset: 20 })
 \`\`\`typescript
 interface FindManyOptions {
   limit:    number          // required
-  offset?:  number          // default: 0
+  offset?:  number          // default: 0; runtime cap: 100000
   orderBy?: OrderBy         // optional ordering
   where?:   Where | SQL     // optional filter
 }
@@ -54,6 +54,8 @@ await User.findMany({ limit: 10, orderBy: { column: 'createdAt', direction: 'des
 // Multiple fields
 await User.findMany({ limit: 10, orderBy: [{ column: 'name' }, { column: 'createdAt', direction: 'desc' }] })
 \`\`\`
+
+**\`offset\` runtime cap:** \`offset\` is capped at 100,000 to prevent read amplification and DoS. Requests above that throw \`HTTPException(400)\`. If you need to paginate deeper, use cursor pagination (e.g., \`id > lastId\`) instead of offset/limit.
 
 ## findAll
 
@@ -235,7 +237,7 @@ const page2 = await User.findMany({ limit: 20, offset: 20 })
 \`\`\`typescript
 interface FindManyOptions {
   limit:    number          // 必須
-  offset?:  number          // デフォルト: 0
+  offset?:  number          // デフォルト: 0; runtime cap: 100000
   orderBy?: OrderBy         // 任意の並び替え
   where?:   Where | SQL     // 任意のフィルタ
 }
@@ -267,6 +269,8 @@ await User.findMany({ limit: 10, orderBy: { column: 'createdAt', direction: 'des
 // 複数フィールド
 await User.findMany({ limit: 10, orderBy: [{ column: 'name' }, { column: 'createdAt', direction: 'desc' }] })
 \`\`\`
+
+**\`offset\` のランタイム上限:** read amplification と DoS を防ぐため、\`offset\` は 100,000 で上限化されています。これを超えると \`HTTPException(400)\` が throw されます。さらに深いページネーションが必要な場合は、offset/limit ではなくカーソルページネーション（例: \`id > lastId\`）を使用してください。
 
 ## findAll
 


### PR DESCRIPTION
## Summary

- `findMany` の `offset` を runtime で 100,000 に上限化し、超過時は `HTTPException(400)` を throw
- SQLite / D1 における巨大 offset を使った read amplification 型 DoS の緩和
- `findAll` は意図的にバイパス（明示的な batch / admin tooling 用途のため）
- README / docs-site (EN/JA) / `llms-full.txt` に offset 上限と cursor pagination 推奨を記載
- `@nanokajs/core` / `create-nanoka-app` を `1.9.0` → `1.10.0` に bump

## 設計判断

- `MAX_OFFSET = 100_000`（module-level const、export しない）
- 超過時挙動: `throw HTTPException(400, { message: 'offset must be <= 100000; use cursor pagination for deeper paging' })`
- `guardOffset` 関数自体は変更せず、guard は `findManyImpl` 内に直接記述（`findAll` 共有のため）
- 型レベル制約は入れない（runtime チェックのみ、`offset: number` のまま）
- バージョニング: minor bump（Issue #49 の `MAX_LIMIT` 廃止と同性質の振る舞い変更扱い）

## 影響範囲

- `findMany({ offset: 100_001 })` → 400
- `findMany({ offset: 100_000 })` → 通常通り
- `findAll({ offset: 100_001 })` → 影響なし（regression test で担保）
- `app.db.select().offset(...)`（escape hatch）→ 影響なし

## Test plan

- [x] `pnpm -C packages/nanoka test:workers`（17 files / 410 tests pass）
- [x] `pnpm -C packages/nanoka test`（node-side: 3 files / 32 tests pass）
- [x] `pnpm -C packages/nanoka typecheck`
- [x] `pnpm -C examples/basic typecheck`
- [x] `pnpm format` / `pnpm lint` / `pnpm build`
- 追加テスト: `findMany` offset 100_001 reject / 100_000 boundary OK / `findAll` regression / router 経由 `app.model().findMany()` でも reject

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)