### PR TITLE
chore(crud): unify biome-ignore for drizzle query cast (#25)

### DIFF
--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -480,10 +480,12 @@ export async function createImpl<Fields extends Record<string, Field<any, any, a
   table: SQLiteTableWithColumns<any>,
   data: CreateInput<Fields>,
 ): Promise<RowType<Fields>> {
-  const rows = await (adapter.drizzle
+  const builder = adapter.drizzle
     .insert(table)
     .values(data as any)
-    .returning() as any)
+    .returning()
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle query type
+  const rows = await (builder as any)
   return rows[0]
 }
 
@@ -516,11 +518,13 @@ export async function updateImpl<Fields extends Record<string, Field<any, any, a
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }
 
-  const rows = await (adapter.drizzle
+  const builder = adapter.drizzle
     .update(table)
     .set(data as any)
     .where(whereClause)
-    .returning() as any)
+    .returning()
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle query type
+  const rows = await (builder as any)
   return rows.length > 0 ? rows[0] : null
 }
 


### PR DESCRIPTION
## Summary

- Add `// biome-ignore lint/suspicious/noExplicitAny: drizzle query type` to the outer `as any` cast in `createImpl` / `updateImpl`, matching the existing `findOneImpl` style.
- Refactor both functions to extract the drizzle builder into a `const builder = ...` variable so the suppression sits on the line directly preceding the cast (Biome line-based suppression). No behavior change — only comment placement and line layout.
- Patch version bump 1.10.0 → 1.10.1 across `@nanokajs/core` and `create-nanoka-app`.

Biome warnings on `crud.ts`: 48 → 46 (−2), `suppressions/unused`: 0.

Closes #25

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint` (exit 0)
- [x] `pnpm exec biome check packages/nanoka/src/model/crud.ts` — warning −2, unused suppressions 0
- [x] `pnpm -C packages/nanoka typecheck`
- [x] `pnpm -C packages/nanoka test` (32 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)