### PR TITLE
chore(ci): add @nanokajs/auth publish pipeline with independent auth-v* tags

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -23,6 +23,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm -C packages/nanoka build
+
       - run: pnpm -C packages/nanoka publish --dry-run --no-git-checks
 
       - name: Build create-nanoka-app
@@ -30,4 +32,10 @@ jobs:
 
       - name: Publish create-nanoka-app (dry run)
         working-directory: packages/create-nanoka-app
+        run: pnpm publish --dry-run --no-git-checks
+
+      - run: pnpm -C packages/nanoka-auth build
+
+      - name: Publish @nanokajs/auth (dry run)
+        working-directory: packages/nanoka-auth
         run: pnpm publish --dry-run --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,6 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag is on main
-        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           if ! git branch -r --contains "${GITHUB_SHA}" | grep -qE "^\s*origin/main$"; then
@@ -42,7 +41,6 @@ jobs:
           fi
 
       - name: Verify tag matches package.json version
-        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./packages/nanoka/package.json').version")
@@ -112,7 +110,6 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag is on main
-        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           if ! git branch -r --contains "${GITHUB_SHA}" | grep -qE "^\s*origin/main$"; then
@@ -121,7 +118,6 @@ jobs:
           fi
 
       - name: Verify tag matches package.json version
-        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./packages/nanoka-auth/package.json').version")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+      - 'auth-v*'
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which package set to publish'
+        type: choice
+        options:
+          - core
+          - auth
+        required: true
 
 permissions:
   id-token: write
@@ -15,7 +24,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  publish-core:
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'core') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,6 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag is on main
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           if ! git branch -r --contains "${GITHUB_SHA}" | grep -qE "^\s*origin/main$"; then
@@ -31,6 +42,7 @@ jobs:
           fi
 
       - name: Verify tag matches package.json version
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./packages/nanoka/package.json').version")
@@ -89,4 +101,59 @@ jobs:
 
       - name: Publish create-nanoka-app to npm
         working-directory: packages/create-nanoka-app
+        run: npm publish --provenance
+
+  publish-auth:
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/auth-v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'auth') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          if ! git branch -r --contains "${GITHUB_SHA}" | grep -qE "^\s*origin/main$"; then
+            echo "::error::Tag ${GITHUB_REF_NAME} is not on main branch."
+            exit 1
+          fi
+
+      - name: Verify tag matches package.json version
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/nanoka-auth/package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#auth-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=${TAG_VERSION}) does not match @nanokajs/auth package.json version ${PKG_VERSION}."
+            exit 1
+          fi
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4.4.0 / v5.0.0 (same commit)
+        with:
+          version: 9.15.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - run: npm install -g npm@^11.5.1
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build @nanokajs/core (workspace dependency)
+        run: pnpm -C packages/nanoka build
+
+      - run: pnpm -C packages/nanoka-auth build
+
+      - run: pnpm -C packages/nanoka-auth test
+
+      - run: pnpm -C packages/nanoka-auth typecheck
+
+      - name: Publish @nanokajs/auth to npm
+        working-directory: packages/nanoka-auth
         run: npm publish --provenance

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,8 +21,10 @@ jobs:
         include:
           - package: packages/nanoka
             tag_prefix: v
+            target: core
           - package: packages/nanoka-auth
             tag_prefix: auth-v
+            target: auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -54,4 +56,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run publish.yml --ref "${{ steps.create_tag.outputs.tag }}"
+          gh workflow run publish.yml \
+            --ref "${{ steps.create_tag.outputs.tag }}" \
+            -f target=${{ matrix.target }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,6 +15,14 @@ concurrency:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: packages/nanoka
+            tag_prefix: v
+          - package: packages/nanoka-auth
+            tag_prefix: auth-v
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -23,13 +31,13 @@ jobs:
       - name: Read version from package.json
         id: version
         run: |
-          VERSION=$(node -p "require('./packages/nanoka/package.json').version")
+          VERSION=$(node -p "require('./${{ matrix.package }}/package.json').version")
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag if not exists
         id: create_tag
         run: |
-          TAG="v${{ steps.version.outputs.value }}"
+          TAG="${{ matrix.tag_prefix }}${{ steps.version.outputs.value }}"
           if git tag -l "${TAG}" | grep -q "${TAG}"; then
             echo "Tag ${TAG} already exists, skipping."
             echo "created=false" >> "$GITHUB_OUTPUT"
@@ -38,6 +46,7 @@ jobs:
             git push origin "${TAG}"
             echo "Created and pushed ${TAG}."
             echo "created=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Trigger publish workflow
@@ -45,4 +54,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run publish.yml --ref "v${{ steps.version.outputs.value }}"
+          gh workflow run publish.yml --ref "${{ steps.create_tag.outputs.tag }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ Any change to `packages/nanoka` or `packages/create-nanoka-app` must include a v
 
 When in doubt between patch and minor, use minor. When in doubt between minor and major, stop and confirm with the user — a wrong major bump is recoverable, but a missed major bump breaks users silently.
 
+`@nanokajs/auth` (`packages/nanoka-auth`) is versioned independently from `@nanokajs/core`. Use the same patch/minor/major rules above, but the version number does **not** track core. Tags use the `auth-v` prefix (e.g. `auth-v1.7.0`); `auto-tag` and `publish` workflows route core under `v*` and auth under `auth-v*`. Any change to `packages/nanoka-auth` must include an auth version bump in the same PR.
+
 ## Security review triggers
 
 Run or request a security-focused review when a change touches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ Any change to `packages/nanoka` or `packages/create-nanoka-app` must include a v
 
 When in doubt between patch and minor, use minor. When in doubt between minor and major, stop and confirm with the user — a wrong major bump is recoverable, but a missed major bump breaks users silently.
 
+`@nanokajs/auth` (`packages/nanoka-auth`) is versioned independently from `@nanokajs/core`. Use the same patch/minor/major rules above, but the version number does **not** track core. Tags use the `auth-v` prefix (e.g. `auth-v1.7.0`); `auto-tag` and `publish` workflows route core under `v*` and auth under `auth-v*`. Any change to `packages/nanoka-auth` must include an auth version bump in the same PR.
+
 ## Security review triggers
 
 Run or request a security-focused review when a change touches:


### PR DESCRIPTION
## Summary

- `@nanokajs/auth` を独立タグ運用 (`auth-v*`) で publish できるように CI を拡張
- `publish.yml` を `publish-core` / `publish-auth` の 2 job 構成に変更。`v*` push で core/CLI、`auth-v*` push で auth を publish。`workflow_dispatch` には `target` (core/auth) の choice input を追加
- `tag.yml` を matrix 化し、`packages/nanoka` → `v*`、`packages/nanoka-auth` → `auth-v*` の両方を自動タグ
- `publish-dry-run.yml` に `@nanokajs/auth` の build + dry-run を追加
- `CLAUDE.md` / `AGENTS.md` の Versioning 節に「auth は core と独立バージョン、タグは `auth-v` prefix」のルールを追記

## Background

`@nanokajs/core` は v1.10.1 まで進む一方、`@nanokajs/auth` は v1.6.0 でズレており、両者を同期させるのは現実的ではない。auth は core を peerDependency `^1.0.0` で参照するだけで、リリースサイクルを縛る必要がない。独立タグ運用にすることで、core のバージョンを動かさずに auth を patch リリースできる。

## Post-merge checklist (外部作業)

- [ ] npmjs.com で `@nanokajs/auth` の trusted publisher を登録（リポジトリ `nanokajs/nanoka` / workflow `.github/workflows/publish.yml` / environment 無し）
- [ ] 初回 publish 後、`@nanokajs/auth` が npm に表示されるか確認

## Test plan

- [x] `pnpm -C packages/nanoka build` 成功
- [x] `pnpm -C packages/nanoka-auth build / test / typecheck` すべて pass (78 tests)
- [x] `pnpm format` 差分なし
- [ ] マージ後、main push で `tag.yml` が matrix 並列実行され `v1.10.1` (既存スキップ) / `auth-v1.6.0` (新規作成) を生成することを確認
- [ ] `auth-v1.6.0` タグ作成で `publish-auth` job のみが発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)