### PR TITLE
feat(model): allow SQL expression & { in } operator in findOne/update/delete where (#139)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -40,6 +40,7 @@
 - `toOpenAPISchema('output', { with })` による relations nested 展開（spec-only、runtime は Zod のまま） — [#91](https://github.com/nanokajs/nanoka/issues/91)
 - `findMany` の `offset` runtime cap = 100_000 — [#18](https://github.com/nanokajs/nanoka/issues/18)
 - `t.timestamp().defaultNow()` — DB の DEFAULT 句として epoch-ms 式を出力。`nanoka generate` 警告ゼロ — [#135](https://github.com/nanokajs/nanoka/issues/135)
+- mutation/findOne の where に Drizzle SQL 式・最小 in 演算子 — [#139](https://github.com/nanokajs/nanoka/issues/139)
 
 ### AI coding support
 

--- a/docs/nanoka.md
+++ b/docs/nanoka.md
@@ -184,6 +184,10 @@ const result = await app.db
 - VSCode extension（TypeScript 言語サーバ + Biome + nanoka generate で十分。Issue #16 参照）
 - フィールドアクセサAPIをMVPに含めない（Phase 2以降）
 
+> **where 表現力の対称化（escape hatch 対称化、DSL 化ではない）**: `findOne` / `update` / `delete` の `idOrWhere` は `findMany` の `where` と対称に Drizzle `SQL` 式を受け付ける（`findOne(inArray(t.id, chunk))`）。`Where` オブジェクトの値に最小限の `{ in: [...] }` 演算子も追加した。これは `app.db` 直叩きを減らすための escape hatch 対称化であり、DSL 化ではない。サポートする演算子オブジェクトは `in` のみ（`and / or / lt / gt / like` は Drizzle 式か `app.db` で書く）。json フィールドは型上 `{ in: [...] }` を受け付けるが、ランタイムでは常に等値比較される（IN 演算子は非 json フィールドのみ）。
+> 
+> `where` 値はバリデータ（`c.req.valid(...)`）経由で構築し、生の query/param オブジェクトを直接渡さないこと。`{ field: { in: [...] } }` の `in` は配列を IN マッチに使うため、未検証入力を直接流すと意図しない IN セマンティクスや大量マッチを招きうる。— [#139](https://github.com/nanokajs/nanoka/issues/139)
+
 > **成長戦略**: 薄いラッパーとして始め、使われたらフレームワークに育てる。スコープを広げるタイミングはユーザーの声が判断基準。名乗るのは後でいい。
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -257,9 +257,14 @@ Options: `{ offset?, orderBy?, where? }`. No `limit` parameter. Issues no LIMIT 
 
 **`findOne(idOrWhere)`** — fetch single row
 
+`idOrWhere` accepts a primary key scalar, a where equality object, a `{ field: { in: [...] } }` operator object, or a Drizzle SQL expression. Symmetric with `findMany` / `findAll` `where`.
+
 ```ts
 const user = await User.findOne(userId)  // by primary key
 const user = await User.findOne({ email: 'alice@example.com' })  // by where clause (AND all conditions)
+const user = await User.findOne({ role: { in: ['admin', 'mod'] } })  // in operator
+import { eq } from 'drizzle-orm'
+const user = await User.findOne(eq(User.table.email, 'alice@example.com'))  // Drizzle SQL
 ```
 
 **`create(input)`**
@@ -275,21 +280,38 @@ const user = await User.create({
 
 **`update(idOrWhere, data)`** — update single row(s)
 
+`idOrWhere` accepts a primary key scalar, a where equality object, a `{ field: { in: [...] } }` operator object, or a Drizzle SQL expression.
+
 ```ts
 const updated = await User.update(userId, { email: 'new@example.com' })
 // or by where clause:
 const updated = await User.update({ email: 'old@example.com' }, { email: 'new@example.com' })
+// or by in operator:
+await User.update({ id: { in: ['id-1', 'id-2'] } }, { role: 'suspended' })
+// or by Drizzle SQL expression:
+import { inArray } from 'drizzle-orm'
+await Session.update(inArray(Session.table.userId, userIds), { expired: true })
 ```
 
-**`delete(idOrWhere)`** — delete row(s) by id or where clause
+**`delete(idOrWhere)`** — delete row(s) by id, where clause, in operator, or Drizzle SQL expression
 
 ```ts
 await User.delete(userId)
 // or by where clause:
 await User.delete({ email: 'alice@example.com' })
+// or by in operator:
+await Session.delete({ userId: { in: expiredUserIds } })
+// inArray chunk splitting — avoids D1 bind limit (100 per query):
+import { inArray } from 'drizzle-orm'
+const chunkSize = 50
+for (let i = 0; i < ids.length; i += chunkSize) {
+  await Session.delete(inArray(Session.table.id, ids.slice(i, i + chunkSize)))
+}
 ```
 
 Returns `{ readonly deleted: number }`.
+
+**`in` operator notes:** `{ field: { in: [...] } }` is supported in all `where` positions (`findMany`, `findAll`, `findOne`, `update`, `delete`). `{ in: [] }` empty array matches 0 rows. JSON fields whose stored value happens to be `{ in: [...] }` in shape are always compared by equality at runtime — the `in` operator applies to non-JSON fields only.
 
 ### 4.9 `t.json(zodSchema)`
 

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@nanokajs/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] — 2026-06-06
+
+### Added
+
+- `findOne` / `update` / `delete` の `idOrWhere` に Drizzle `SQL` 式を渡せるよう対称化（`findMany` / `findAll` の `where: SQL` と同等）。`Session.delete(inArray(Session.table.id, chunk))` のように D1 バインド上限（100）回避の `inArray` チャンク分割が Model API で書けるようになった。
+- `Where` 値型に最小 `{ in: [...] }` 演算子を追加（`WhereValue<T>` 型として export）。`findMany` / `findAll` / `findOne` / `update` / `delete` 全 where 経路で一貫して使える。空配列 `{ in: [] }` は 0 行マッチ。json フィールドの値が `{ in: [...] }` 形でも型上は演算子と区別できないが、ランタイムでは json フィールドは常に等値比較される。
+- `WhereValue<T>` 型を `@nanokajs/core` から export。
+
+### Notes
+
+- 後方互換。PK スカラー・等値 AND オブジェクト・空 where 400 ガード・prototype pollution ガードは従来どおり動作する。
+- サポートする演算子オブジェクトは `in` のみ（escape hatch 対称化）。`and / or / lt / gt / like` はDrizzle 式か `app.db` で書く。
+
 ## [1.11.0] — 2026-06-05
 
 ### Added

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -17,7 +17,7 @@ Targets **Cloudflare Workers + D1 (SQLite)** as first-class. Hono-compatible rou
 
 ## Status
 
-**Stable (1.11.0).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()` — is stable under SemVer.
+**Stable (1.12.0).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()`, mutation/findOne SQL expression and `in` operator in `where` — is stable under SemVer.
 
 ## Stable API surface (1.0)
 
@@ -333,7 +333,19 @@ const specific = await User.findMany({
 })
 ```
 
+The `where` field also accepts `{ field: { in: [...] } }` for IN matching:
+
+```ts
+// IN operator — equality OR over a set of values
+const selected = await User.findMany({
+  limit: 50,
+  where: { role: { in: ['admin', 'moderator'] } },
+})
+```
+
 When passing a Drizzle SQL expression, SQL injection prevention follows Drizzle's parametrized binding rules — ensure all user-supplied values are passed as Drizzle operands (e.g., `like(col, value)`) rather than interpolated into raw strings. Never pass user input to `sql.raw()`, which skips parametrization entirely.
+
+Build `where` values from validated input (`c.req.valid(...)`); do not pass raw query/param objects directly. The `{ in: [...] }` operator uses the array for IN matching, so unvalidated input could trigger unintended IN semantics or large match sets.
 
 **`offset` runtime cap:** `offset` is capped at 100,000 to prevent read amplification and DoS. If you need to paginate deeper, use cursor pagination (e.g., `id > lastId`) instead of offset/limit.
 
@@ -355,6 +367,33 @@ return c.json(User.toResponseMany(users))
 `findAll` accepts `offset`, `orderBy`, and `where` — the same semantics as `findMany`. It does **not** accept `limit`.
 
 **Warning:** `findAll` issues no LIMIT to the database. For request handlers, enforce an app-level size guard or use `findMany` with an explicit `limit` instead.
+
+### `findOne` / `update` / `delete` — Drizzle SQL and `in` operator
+
+`findOne`, `update`, and `delete` accept the same where expression forms as `findMany`: a primary key scalar, a plain equality object, a `{ field: { in: [...] } }` operator object, or a Drizzle SQL expression.
+
+```ts
+import { eq, inArray } from 'drizzle-orm'
+
+// By primary key (unchanged)
+await Session.delete('session-id')
+
+// By equality object (unchanged)
+await User.findOne({ email: 'alice@example.com' })
+
+// By { in: [...] } operator
+await Session.delete({ userId: { in: ['u-1', 'u-2', 'u-3'] } })
+
+// By Drizzle SQL expression — e.g., inArray for D1 bind limit (100) workaround
+const ids = ['id-1', 'id-2', /* ... 110 ids total ... */]
+const chunkSize = 50
+for (let i = 0; i < ids.length; i += chunkSize) {
+  const chunk = ids.slice(i, i + chunkSize)
+  await Session.delete(inArray(Session.table.id, chunk))
+}
+```
+
+SQL injection prevention follows Drizzle's parametrized binding rules for all forms above. The `{ in: [] }` empty array is valid and matches 0 rows. JSON fields typed as `{ in: [...] }` by coincidence are always compared by equality at runtime — the `in` operator applies to non-JSON fields only.
 
 ## Escape hatch: raw Drizzle and D1 batch
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",

--- a/packages/nanoka/src/model/__tests__/crud.integration.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.integration.test.ts
@@ -1,5 +1,5 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import { eq, like, or, sql } from 'drizzle-orm'
+import { eq, inArray, like, or, sql } from 'drizzle-orm'
 import { HTTPException } from 'hono/http-exception'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { d1Adapter } from '../../adapter/d1'
@@ -899,5 +899,226 @@ describe('findAll', () => {
       // biome-ignore lint/suspicious/noExplicitAny: intentional invalid offset for guard test
       AllUser.findAll(adapter, { offset: 1.5 as any }),
     ).rejects.toThrow(HTTPException)
+  })
+})
+
+describe('SQL expression and in operator — findOne/update/delete', () => {
+  const SqlModel = defineModel('sql_users', {
+    id: t.string().primary(),
+    name: t.string(),
+    role: t.string(),
+  })
+
+  const JsonModel = defineModel('json_users', {
+    id: t.string().primary(),
+    // biome-ignore lint/suspicious/noExplicitAny: json field with unknown shape for test
+    meta: t.json<{ in: string[] } | unknown>(),
+  })
+
+  beforeEach(async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS sql_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE sql_users (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          role TEXT NOT NULL
+        )
+      `,
+    )
+
+    await adapter.drizzle.run(sql`DROP TABLE IF EXISTS json_users`)
+    await adapter.drizzle.run(
+      sql`
+        CREATE TABLE json_users (
+          id TEXT PRIMARY KEY,
+          meta TEXT NOT NULL
+        )
+      `,
+    )
+
+    await SqlModel.create(adapter, { id: 'su-1', name: 'Alice', role: 'admin' })
+    await SqlModel.create(adapter, { id: 'su-2', name: 'Bob', role: 'user' })
+    await SqlModel.create(adapter, { id: 'su-3', name: 'Charlie', role: 'user' })
+    await SqlModel.create(adapter, { id: 'su-4', name: 'Diana', role: 'admin' })
+  })
+
+  it('findOne accepts SQL expression', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const found = await SqlModel.findOne(adapter, eq(SqlModel.table.name, 'Alice'))
+    expect(found).not.toBeNull()
+    expect(found?.name).toBe('Alice')
+  })
+
+  it('update accepts SQL expression', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const updated = await SqlModel.update(adapter, inArray(SqlModel.table.id, ['su-1', 'su-2']), {
+      role: 'moderator',
+    })
+    expect(updated).not.toBeNull()
+
+    const rows = await SqlModel.findMany(adapter, { limit: 10, where: { role: 'moderator' } })
+    const ids = rows.map((r) => r.id).sort()
+    expect(ids).toContain('su-1')
+  })
+
+  it('delete accepts SQL expression', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const result = await SqlModel.delete(adapter, inArray(SqlModel.table.id, ['su-1', 'su-2']))
+    expect(result.deleted).toBe(2)
+
+    const remaining = await SqlModel.findMany(adapter, { limit: 10 })
+    expect(remaining.map((r) => r.id).sort()).toEqual(['su-3', 'su-4'])
+  })
+
+  it('delete with inArray chunk splitting (>100 ids)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    // Create 110 additional rows
+    const extraIds: string[] = []
+    for (let i = 0; i < 110; i++) {
+      const id = `chunk-${String(i).padStart(3, '0')}`
+      extraIds.push(id)
+      await SqlModel.create(adapter, { id, name: `User${i}`, role: 'temp' })
+    }
+
+    // Split into chunks of 50 and delete
+    const chunkSize = 50
+    let totalDeleted = 0
+    for (let i = 0; i < extraIds.length; i += chunkSize) {
+      const chunk = extraIds.slice(i, i + chunkSize)
+      const result = await SqlModel.delete(adapter, inArray(SqlModel.table.id, chunk))
+      totalDeleted += result.deleted
+    }
+
+    expect(totalDeleted).toBe(110)
+
+    // Verify original rows remain
+    const remaining = await SqlModel.findMany(adapter, { limit: 20, where: { role: 'temp' } })
+    expect(remaining.length).toBe(0)
+  })
+
+  it('findOne with { in } operator', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const found = await SqlModel.findOne(adapter, { id: { in: ['su-1', 'su-2', 'su-3'] } })
+    expect(found).not.toBeNull()
+    expect(['su-1', 'su-2', 'su-3']).toContain(found?.id)
+  })
+
+  it('update with { in } operator', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    await SqlModel.update(adapter, { id: { in: ['su-1', 'su-2'] } }, { role: 'updated' })
+
+    const updatedRows = await SqlModel.findMany(adapter, {
+      limit: 10,
+      where: { role: 'updated' },
+    })
+    expect(updatedRows.map((r) => r.id).sort()).toEqual(['su-1', 'su-2'])
+  })
+
+  it('delete with { in } operator', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const result = await SqlModel.delete(adapter, { id: { in: ['su-3', 'su-4'] } })
+    expect(result.deleted).toBe(2)
+
+    const remaining = await SqlModel.findMany(adapter, { limit: 10 })
+    expect(remaining.map((r) => r.id).sort()).toEqual(['su-1', 'su-2'])
+  })
+
+  it('findMany with { in } operator', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const rows = await SqlModel.findMany(adapter, {
+      limit: 10,
+      where: { role: { in: ['admin', 'user'] } },
+    })
+    expect(rows.length).toBe(4)
+
+    const adminRows = await SqlModel.findMany(adapter, {
+      limit: 10,
+      where: { role: { in: ['admin'] } },
+    })
+    expect(adminRows.length).toBe(2)
+    expect(adminRows.every((r) => r.role === 'admin')).toBe(true)
+  })
+
+  it('{ in: [] } empty array returns 0 rows', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const found = await SqlModel.findOne(adapter, { id: { in: [] } })
+    expect(found).toBeNull()
+
+    const result = await SqlModel.delete(adapter, { id: { in: [] } })
+    expect(result.deleted).toBe(0)
+  })
+
+  it('json { in }-shaped value is treated as equality (not IN operator)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    // Insert a row whose meta JSON value happens to have { in: ['x'] } shape
+    // json columns serialize/deserialize via JSON.stringify/parse
+    const inShapedValue = { in: ['x'] }
+    await JsonModel.create(adapter, { id: 'j-1', meta: inShapedValue })
+    await JsonModel.create(adapter, { id: 'j-2', meta: { foo: 'bar' } })
+
+    // findOne with meta: { in: ['x'] } should use equality (eq), not inArray
+    // The key invariant: isInOperator returns false for json fields, so eq(col, value) is used.
+    // Because the json column uses Drizzle's mode:'json', eq compares the serialized JSON string.
+    // biome-ignore lint/suspicious/noExplicitAny: intentional test of json equality vs in operator
+    const found = await JsonModel.findOne(adapter, { meta: inShapedValue as any })
+    // The invariant we're testing: the query does NOT become inArray(meta, ['x']).
+    // Drizzle's json-mode column will serialize inShapedValue via its own mapTo, so this
+    // equals the stored value — 1 row is expected.
+    expect(found).not.toBeNull()
+    expect(found?.id).toBe('j-1')
+  })
+
+  it('equality AND / PK scalar still works (regression)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const byEmail = await SqlModel.findOne(adapter, { name: 'Bob', role: 'user' })
+    expect(byEmail).not.toBeNull()
+    expect(byEmail?.id).toBe('su-2')
+
+    const byPk = await SqlModel.findOne(adapter, 'su-1')
+    expect(byPk).not.toBeNull()
+    expect(byPk?.name).toBe('Alice')
+  })
+
+  it('empty where object still rejected (regression)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional empty where for guard test
+    await expect(SqlModel.delete(adapter, {} as any)).rejects.toThrow(HTTPException)
+  })
+
+  it('prototype pollution guard holds (regression)', async () => {
+    const { env } = await import('cloudflare:test')
+    const adapter = d1Adapter(env.DB)
+
+    const malicious = JSON.parse('{"toString": "x"}')
+    // biome-ignore lint/suspicious/noExplicitAny: intentionally passing invalid type to test runtime validation
+    await expect(SqlModel.findOne(adapter, malicious as any)).rejects.toThrow(HTTPException)
   })
 })

--- a/packages/nanoka/src/model/__tests__/crud.types.test.ts
+++ b/packages/nanoka/src/model/__tests__/crud.types.test.ts
@@ -1,9 +1,17 @@
-import { like } from 'drizzle-orm'
+import { inArray, like } from 'drizzle-orm'
 import { describe, it } from 'vitest'
 import type { Adapter } from '../../adapter/types'
 import { t } from '../../field'
 import { defineModel } from '../define'
-import type { CreateInput, FindAllOptions, FindManyOptions, RowType, WithOptions } from '../types'
+import type {
+  CreateInput,
+  FindAllOptions,
+  FindManyOptions,
+  IdOrWhere,
+  RowType,
+  WhereValue,
+  WithOptions,
+} from '../types'
 
 describe('CRUD methods: type checking', () => {
   const User = defineModel('users', {
@@ -351,6 +359,110 @@ describe('CRUD methods: type checking', () => {
 
     it('accepts where object', () => {
       const _: Parameters<typeof User.delete>[1] = { email: 'test@example.com' }
+      void _
+    })
+  })
+})
+
+describe('SQL expression and in operator — type constraints', () => {
+  const User = defineModel('users_type_test', {
+    id: t.string().primary(),
+    name: t.string(),
+    role: t.string(),
+  })
+
+  const NumericUser = defineModel('numeric_users', {
+    id: t.integer().primary(),
+    name: t.string(),
+  })
+
+  describe('findOne/update/delete accept SQL expression', () => {
+    it('findOne accepts Drizzle SQL (like)', () => {
+      const _: IdOrWhere<typeof User.fields> = like(User.table.name, '%x%')
+      void _
+    })
+
+    it('findOne accepts Drizzle SQL (inArray)', () => {
+      const _: IdOrWhere<typeof User.fields> = inArray(User.table.id, ['a', 'b'])
+      void _
+    })
+
+    it('update accepts Drizzle SQL', () => {
+      const _: Parameters<typeof User.update>[1] = inArray(User.table.id, ['a', 'b'])
+      void _
+    })
+
+    it('delete accepts Drizzle SQL', () => {
+      const _: Parameters<typeof User.delete>[1] = inArray(User.table.id, ['a', 'b'])
+      void _
+    })
+  })
+
+  describe('accept { field: { in: [...] } } operator', () => {
+    it('findOne accepts { id: { in: [...] } }', () => {
+      const _: IdOrWhere<typeof User.fields> = { id: { in: ['a', 'b'] } }
+      void _
+    })
+
+    it('update accepts { id: { in: [...] } }', () => {
+      const _: Parameters<typeof User.update>[1] = { id: { in: ['a', 'b'] } }
+      void _
+    })
+
+    it('delete accepts { id: { in: [...] } }', () => {
+      const _: Parameters<typeof User.delete>[1] = { id: { in: ['a', 'b'] } }
+      void _
+    })
+
+    it('findMany accepts { role: { in: [...] } } in where', () => {
+      const opts: FindManyOptions<typeof User.fields> = {
+        limit: 10,
+        where: { role: { in: ['admin', 'user'] } },
+      }
+      void opts
+    })
+  })
+
+  describe('in element type is checked', () => {
+    it('rejects numeric in array for string id field', () => {
+      // @ts-expect-error - id is string but in contains numbers
+      const _: IdOrWhere<typeof User.fields> = { id: { in: [123] } }
+      void _
+    })
+
+    it('rejects string in array for numeric id field', () => {
+      // @ts-expect-error - id is number but in contains strings
+      const _: IdOrWhere<typeof NumericUser.fields> = { id: { in: ['a'] } }
+      void _
+    })
+  })
+
+  describe('WhereValue type', () => {
+    it('accepts scalar value', () => {
+      const _: WhereValue<string> = 'hello'
+      void _
+    })
+
+    it('accepts { in: [...] } operator', () => {
+      const _: WhereValue<string> = { in: ['a', 'b'] }
+      void _
+    })
+  })
+
+  describe('regression: existing type constraints', () => {
+    it('nonexistent field in where is rejected', () => {
+      // @ts-expect-error - 'nonexistent' is not a field
+      const _: Parameters<typeof User.findOne>[1] = { nonexistent: 'value' }
+      void _
+    })
+
+    it('scalar id still accepted by findOne', () => {
+      const _: Parameters<typeof User.findOne>[1] = 'some-id'
+      void _
+    })
+
+    it('scalar id still accepted by delete', () => {
+      const _: Parameters<typeof User.delete>[1] = 'some-id'
       void _
     })
   })

--- a/packages/nanoka/src/model/crud.ts
+++ b/packages/nanoka/src/model/crud.ts
@@ -83,6 +83,22 @@ function findPrimaryKey(
 }
 
 /**
+ * Detects whether a value is an `{ in: [...] }` operator object for a non-json field.
+ * @internal
+ */
+// biome-ignore lint/suspicious/noExplicitAny: field constraint
+function isInOperator(value: unknown, field: Field<any, any, any> | undefined): boolean {
+  return (
+    field?.kind !== 'json' &&
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.hasOwn(value, 'in') &&
+    Array.isArray((value as { in: unknown }).in)
+  )
+}
+
+/**
  * Constructs a Drizzle where clause from an object.
  * All entries are combined with AND.
  * @internal
@@ -92,7 +108,7 @@ function buildWhereClause(
   fields: Record<string, Field<any, any, any>>,
   where: Where<Record<string, any>>,
 ): ReturnType<typeof and> | null {
-  const conditions: ReturnType<typeof eq>[] = []
+  const conditions: SQL[] = []
 
   for (const [key, value] of Object.entries(where)) {
     // Multi-layered guard against identifier injection
@@ -104,16 +120,22 @@ function buildWhereClause(
     }
     // biome-ignore lint/suspicious/noExplicitAny: table column access is runtime-guarded by hasOwn
     const col = (table as unknown as Record<string, any>)[key]
-    conditions.push(eq(col, value))
+    const field = fields[key]
+    if (isInOperator(value, field)) {
+      conditions.push(inArray(col, (value as { in: unknown[] }).in))
+    } else {
+      conditions.push(eq(col, value))
+    }
   }
 
   if (conditions.length === 0) {
     return null
   }
+  // conditions is SQL[] (inArray/eq both return SQL); cast to satisfy Drizzle's and()/return type which expects the narrower eq() result shape. Safe at runtime — all elements are SQL wrappers.
   if (conditions.length === 1) {
-    return conditions[0]
+    return conditions[0] as ReturnType<typeof eq>
   }
-  return and(...conditions)
+  return and(...(conditions as ReturnType<typeof eq>[]))
 }
 
 function resolveRelationTarget(field: RelationDef): RelationTargetLike {
@@ -437,20 +459,25 @@ export async function findOneImpl<Fields extends Record<string, Field<any, any, 
   idOrWhere: IdOrWhere<Fields>,
   options?: FindOneOptions<Fields>,
 ): Promise<RowType<Fields> | null> {
-  let where: Where<Fields> | null = null
+  let whereClause: SQL | ReturnType<typeof buildWhereClause>
 
-  if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
-    // PK mode
-    const pk = findPrimaryKey(fields)
-    if (!pk) {
-      throw new HTTPException(500, { message: 'model has no primary key' })
-    }
-    where = { [pk[0]]: idOrWhere } as Where<Fields>
+  if (idOrWhere instanceof SQL) {
+    whereClause = idOrWhere
   } else {
-    where = idOrWhere as Where<Fields>
+    let where: Where<Fields>
+    if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
+      // PK mode
+      const pk = findPrimaryKey(fields)
+      if (!pk) {
+        throw new HTTPException(500, { message: 'model has no primary key' })
+      }
+      where = { [pk[0]]: idOrWhere } as Where<Fields>
+    } else {
+      where = idOrWhere as Where<Fields>
+    }
+    whereClause = buildWhereClause(table, fields, where)
   }
 
-  const whereClause = buildWhereClause(table, fields, where)
   if (!whereClause) {
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }
@@ -500,20 +527,25 @@ export async function updateImpl<Fields extends Record<string, Field<any, any, a
   idOrWhere: IdOrWhere<Fields>,
   data: Partial<RowType<Fields>>,
 ): Promise<RowType<Fields> | null> {
-  let where: Where<Fields> | null = null
+  let whereClause: SQL | ReturnType<typeof buildWhereClause>
 
-  if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
-    // PK mode
-    const pk = findPrimaryKey(fields)
-    if (!pk) {
-      throw new HTTPException(500, { message: 'model has no primary key' })
-    }
-    where = { [pk[0]]: idOrWhere } as Where<Fields>
+  if (idOrWhere instanceof SQL) {
+    whereClause = idOrWhere
   } else {
-    where = idOrWhere as Where<Fields>
+    let where: Where<Fields>
+    if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
+      // PK mode
+      const pk = findPrimaryKey(fields)
+      if (!pk) {
+        throw new HTTPException(500, { message: 'model has no primary key' })
+      }
+      where = { [pk[0]]: idOrWhere } as Where<Fields>
+    } else {
+      where = idOrWhere as Where<Fields>
+    }
+    whereClause = buildWhereClause(table, fields, where)
   }
 
-  const whereClause = buildWhereClause(table, fields, where)
   if (!whereClause) {
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }
@@ -538,20 +570,25 @@ export async function deleteImpl<Fields extends Record<string, Field<any, any, a
   fields: Fields,
   idOrWhere: IdOrWhere<Fields>,
 ): Promise<{ readonly deleted: number }> {
-  let where: Where<Fields> | null = null
+  let whereClause: SQL | ReturnType<typeof buildWhereClause>
 
-  if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
-    // PK mode
-    const pk = findPrimaryKey(fields)
-    if (!pk) {
-      throw new HTTPException(500, { message: 'model has no primary key' })
-    }
-    where = { [pk[0]]: idOrWhere } as Where<Fields>
+  if (idOrWhere instanceof SQL) {
+    whereClause = idOrWhere
   } else {
-    where = idOrWhere as Where<Fields>
+    let where: Where<Fields>
+    if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
+      // PK mode
+      const pk = findPrimaryKey(fields)
+      if (!pk) {
+        throw new HTTPException(500, { message: 'model has no primary key' })
+      }
+      where = { [pk[0]]: idOrWhere } as Where<Fields>
+    } else {
+      where = idOrWhere as Where<Fields>
+    }
+    whereClause = buildWhereClause(table, fields, where)
   }
 
-  const whereClause = buildWhereClause(table, fields, where)
   if (!whereClause) {
     throw new HTTPException(400, { message: 'where clause must not be empty' })
   }

--- a/packages/nanoka/src/model/types.ts
+++ b/packages/nanoka/src/model/types.ts
@@ -111,22 +111,32 @@ export type OrderBy<
     >
 
 /**
- * Where clause object: each key is a field name, each value is the desired equality.
+ * A single where value: either an equality value or an `{ in: [...] }` operator for IN matching.
+ * Note: json fields whose stored value happens to be `{ in: [...] }` in shape are still treated
+ * as equality at runtime — the IN operator is applied to non-json fields only.
+ */
+export type WhereValue<T> = T | { readonly in: readonly T[] }
+
+/**
+ * Where clause object: each key is a field name, each value is the desired equality, or an
+ * `{ in: [...] }` operator for IN matching.
+ * json フィールドの値が偶然 `{ in: [...] }` 形でも型上は演算子と区別できないが、ランタイムでは
+ * json フィールドは常に等値比較される（IN 演算子は非 json フィールドのみ）。
  */
 export type Where<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
 > = {
-  readonly [K in NonRelationKeys<Fields>]?: InferFieldType<Fields[K]>
+  readonly [K in NonRelationKeys<Fields>]?: WhereValue<InferFieldType<Fields[K]>>
 }
 
 /**
- * Identifier or Where clause: can be a primary key value or a Where object.
+ * Identifier or Where clause: can be a primary key value, a Where object, or a Drizzle SQL expression.
  */
 export type IdOrWhere<
   // biome-ignore lint/suspicious/noExplicitAny: any is necessary for Field constraint
   Fields extends Record<string, Field<any, any, any>>,
-> = string | number | Where<Fields>
+> = string | number | Where<Fields> | SQL
 
 /**
  * Row type: full record type from fields, excluding relation fields.

--- a/site/src/content/api/crud.ts
+++ b/site/src/content/api/crud.ts
@@ -70,7 +70,7 @@ In request handlers, always prefer \`findMany\` with an explicit limit.
 
 ## findOne
 
-Fetches a single row by primary key value or where clause. Returns \`null\` if no row matches.
+Fetches a single row by primary key value, where clause, or Drizzle SQL expression. Returns \`null\` if no row matches.
 
 \`\`\`typescript
 // By primary key value
@@ -78,6 +78,13 @@ const user = await User.findOne('uuid-value')
 
 // By where clause
 const user = await User.findOne({ email: 'alice@example.com' })
+
+// By { in: [...] } operator
+const user = await User.findOne({ role: { in: ['admin', 'moderator'] } })
+
+// By Drizzle SQL expression
+import { eq } from 'drizzle-orm'
+const user = await User.findOne(eq(User.table.email, 'alice@example.com'))
 
 // Typical 404 pattern
 import { HTTPException } from 'hono/http-exception'
@@ -115,7 +122,7 @@ await app.db.insert(User.table).values({ ...body, passwordHash })
 
 ## update
 
-Updates rows matching the given id or where clause. Returns the updated row, or \`null\` if no row matched.
+Updates rows matching the given id, where clause, or Drizzle SQL expression. Returns the updated row, or \`null\` if no row matched.
 
 \`\`\`typescript
 // By primary key value
@@ -124,6 +131,13 @@ const updated = await User.update('uuid-value', { name: 'Bob' })
 // By where clause
 const updated = await User.update({ email: 'alice@example.com' }, { name: 'Bob' })
 
+// By { in: [...] } operator
+await User.update({ id: { in: ['id-1', 'id-2'] } }, { role: 'suspended' })
+
+// By Drizzle SQL expression
+import { inArray } from 'drizzle-orm'
+await Session.update(inArray(Session.table.userId, userIds), { expired: true })
+
 // 404 if not found
 if (!updated) throw new HTTPException(404, { message: 'Not found' })
 return c.json(User.toResponse(updated))
@@ -131,11 +145,21 @@ return c.json(User.toResponse(updated))
 
 ## delete
 
-Deletes rows matching the given id or where clause. Returns \`{ deleted: number }\`.
+Deletes rows matching the given id, where clause, or Drizzle SQL expression. Returns \`{ deleted: number }\`.
 
 \`\`\`typescript
 const result = await User.delete('uuid-value')
 console.log(result.deleted) // number of deleted rows
+
+// By { in: [...] } operator
+await Session.delete({ userId: { in: expiredUserIds } })
+
+// inArray chunk splitting — avoids D1 bind limit (100 per query)
+import { inArray } from 'drizzle-orm'
+const chunkSize = 50
+for (let i = 0; i < ids.length; i += chunkSize) {
+  await Session.delete(inArray(Session.table.id, ids.slice(i, i + chunkSize)))
+}
 
 // 404 if nothing was deleted
 if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })
@@ -285,7 +309,7 @@ const activeUsers = await User.findAll({ where: { isActive: true }, orderBy: 'na
 
 ## findOne
 
-主キーの値または where 句で単一の行を取得します。行が見つからない場合は \`null\` を返します。
+主キーの値、where 句、または Drizzle SQL 式で単一の行を取得します。行が見つからない場合は \`null\` を返します。
 
 \`\`\`typescript
 // 主キーの値で
@@ -293,6 +317,13 @@ const user = await User.findOne('uuid-value')
 
 // where 句で
 const user = await User.findOne({ email: 'alice@example.com' })
+
+// { in: [...] } 演算子で
+const user = await User.findOne({ role: { in: ['admin', 'moderator'] } })
+
+// Drizzle SQL 式で
+import { eq } from 'drizzle-orm'
+const user = await User.findOne(eq(User.table.email, 'alice@example.com'))
 
 // 典型的な 404 パターン
 import { HTTPException } from 'hono/http-exception'
@@ -330,7 +361,7 @@ await app.db.insert(User.table).values({ ...body, passwordHash })
 
 ## update
 
-指定した id または where 句に一致する行を更新します。更新された行を返し、一致する行がなければ \`null\` を返します。
+指定した id、where 句、または Drizzle SQL 式に一致する行を更新します。更新された行を返し、一致する行がなければ \`null\` を返します。
 
 \`\`\`typescript
 // 主キーの値で
@@ -339,6 +370,13 @@ const updated = await User.update('uuid-value', { name: 'Bob' })
 // where 句で
 const updated = await User.update({ email: 'alice@example.com' }, { name: 'Bob' })
 
+// { in: [...] } 演算子で
+await User.update({ id: { in: ['id-1', 'id-2'] } }, { role: 'suspended' })
+
+// Drizzle SQL 式で
+import { inArray } from 'drizzle-orm'
+await Session.update(inArray(Session.table.userId, userIds), { expired: true })
+
 // 見つからない場合は 404
 if (!updated) throw new HTTPException(404, { message: 'Not found' })
 return c.json(User.toResponse(updated))
@@ -346,11 +384,21 @@ return c.json(User.toResponse(updated))
 
 ## delete
 
-指定した id または where 句に一致する行を削除します。\`{ deleted: number }\` を返します。
+指定した id、where 句、または Drizzle SQL 式に一致する行を削除します。\`{ deleted: number }\` を返します。
 
 \`\`\`typescript
 const result = await User.delete('uuid-value')
 console.log(result.deleted) // 削除された行数
+
+// { in: [...] } 演算子で
+await Session.delete({ userId: { in: expiredUserIds } })
+
+// inArray チャンク分割 — D1 バインド上限（1 クエリ 100 件）を回避する
+import { inArray } from 'drizzle-orm'
+const chunkSize = 50
+for (let i = 0; i < ids.length; i += chunkSize) {
+  await Session.delete(inArray(Session.table.id, ids.slice(i, i + chunkSize)))
+}
 
 // 削除されなかった場合は 404
 if (result.deleted === 0) throw new HTTPException(404, { message: 'Not found' })


### PR DESCRIPTION
## 概要

`findMany` / `findAll` が `where?: Where | SQL` を受けるのに、`findOne` / `update` / `delete` は等値限定の `IdOrWhere = string | number | Where` しか受けない**非対称**を解消する。

- **(a)** `IdOrWhere` に `| SQL` を追加 → `findOne` / `update` / `delete` が Drizzle SQL 式を受ける（`findMany` と対称）。`Session.delete(adapter, inArray(Session.table.id, chunk))` が書ける。
- **(b)** `Where` 値型に最小 `{ in: [...] }` 演算子を追加（`findMany` / `findAll` / `findOne` / `update` / `delete` の全 `where` 経路で一貫）。

D1 の bind 上限(100)回避の `inArray` チャンク分割が Model API で書けるようになり、`app.db` 直叩きを減らす。後方互換。

出典: #134 day-matcher 採用事例の実測フォローアップ。

## 設計境界（#15 non-goal 遵守）

- サポートする演算子オブジェクトは **`in` のみ**。`and` / `or` / `lt` / `gt` / `like` などフル DSL 化はしない。それらは引き続き素の `| SQL`（Drizzle 演算子）か `app.db` で書く。
- `User.where(f => eq(...)).limit(10)` チェーン DSL（#15 non-goal）は導入しない。
- `docs/implementation-status.md` の Typed query helper non-goal の文言は維持。

## json 曖昧性の解決

`Where` 値を `T | { in: [...] }` に広げると `t.json()` の値がたまたま `{ in: [...] }` 形のとき演算子と誤認しうる。→ `isInOperator` が `field.kind === 'json'` を演算子検出から除外し、json フィールドは常に等値（`eq`）扱い。`{ in: [...] }`-形の json 値が IN に誤変換されないことをテストで実証。json で IN が要るレアケースは素の `| SQL`（`inArray(Model.table.jsonCol, [...])`）で書ける。

## セキュリティ

- 全経路 Drizzle パラメータバインド（`inArray` / `eq` / SQL 式）。文字列連結・`sql.raw()` 経路なし。
- 識別子（カラム名）は `Object.hasOwn(fields)` + `Object.hasOwn(table)` の allowlist ガードで弾く。`in` 演算子分岐もこのガードの内側。
- prototype 汚染ガード（`Object.entries` + `Object.hasOwn(value, 'in')`）・空 where 400 ガードを新経路でも維持。
- defense-in-depth として「`where` 値はバリデータ（`c.req.valid(...)`）経由で構築し、生 query/param を直接渡さない」を README / docs に明記。
- セキュリティレビュー: **approve**（A03 Injection / prototype 汚染とも none）。

## テスト

- 統合 +13（SQL 受領・`inArray` チャンク分割[100 超]・`{ in }` 演算子・空配列 0 行・json 等値・等値/PK/空 where 400/prototype pollution 回帰）
- 型 +11（SQL/`{ in }` 受領・`in` 要素型チェック `@ts-expect-error`・存在しないフィールド拒否・scalar id 回帰）
- Node 35 pass / Workers (D1) 460 pass / typecheck（nanoka + examples）pass

## レビュー

- 実装レビュー: **approve**（Critical 0 / Major 0 / Minor 3 → コード/docs 有意の 2 件は反映済み）
- セキュリティレビュー: **approve**（Critical 0 / Major 0 / Minor 1 → docs 注記反映済み）

## ドキュメント

`docs/nanoka.md` / `docs/implementation-status.md` / `packages/nanoka/README.md` / `packages/nanoka/CHANGELOG.md`（`[1.12.0]`）/ `site/src/content/api/crud.ts`（en/ja）/ `llms-full.txt` を更新。

## バージョン

minor **1.11.0 → 1.12.0**（両パッケージ）。pnpm-lock は依存変更なしのため更新不要。

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
