### PR TITLE
ci(publish): build @nanokajs/auth before examples/basic typecheck (release 1.12.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,9 @@ jobs:
 
       - run: pnpm -C packages/nanoka typecheck
 
+      # examples/basic が @nanokajs/auth に依存するため、typecheck 前に型定義をビルドする
+      - run: pnpm -C packages/nanoka-auth build
+
       - run: pnpm -C examples/basic typecheck
 
       - run: pnpm -C examples/basic test

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@nanokajs/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] — 2026-07-02
+
+### Fixed
+
+- リリース CI 修正のための再公開。`1.10.0`〜`1.12.0` は publish ワークフローの `publish-core` ジョブが `examples/basic` の typecheck 前に `@nanokajs/auth` をビルドしておらず、`TS2307 (Cannot find module '@nanokajs/auth')` で publish が中断し npm 未公開だった。ライブラリ本体のコード変更はなく、`1.12.0` と機能的に同一。
+
 ## [1.12.0] — 2026-06-06
 
 ### Added

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -17,7 +17,7 @@ Targets **Cloudflare Workers + D1 (SQLite)** as first-class. Hono-compatible rou
 
 ## Status
 
-**Stable (1.12.0).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()`, mutation/findOne SQL expression and `in` operator in `where` — is stable under SemVer.
+**Stable (1.12.1).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()`, mutation/findOne SQL expression and `in` operator in `where` — is stable under SemVer.
 
 ## Stable API surface (1.0)
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",


### PR DESCRIPTION
## 背景

`Publish` ワークフローが失敗し続けており、npm の公開は `@nanokajs/core` `1.9.0` で止まっていた（`1.10.0` / `1.10.1` / `1.10.2` / `1.11.0` / `1.12.0` が未公開）。

## 原因

`examples/basic` が `@nanokajs/auth`（`workspace:*`）に依存するようになったが、`publish.yml` の `publish-core` ジョブは `examples/basic typecheck` の前に `@nanokajs/auth` をビルドしていなかった。そのため型定義が存在せず、以下で publish が中断していた:

```
src/index.ts(1,42): error TS2307:
  Cannot find module '@nanokajs/auth' or its corresponding type declarations.
```

`ci.yml` は `pnpm -C packages/nanoka-auth build` を typecheck 前に実行しているため通っていたが、`publish.yml` にはそのステップが欠けていた（両者のステップ構成の食い違い）。

## 変更

- `publish.yml` の `publish-core` に `pnpm -C packages/nanoka-auth build` を `examples/basic typecheck` の前へ追加（`ci.yml` に合わせる）。
- 未公開バージョンを再公開するための patch リリースとして `@nanokajs/core` / `create-nanoka-app` を `1.12.0` → `1.12.1` に bump。ライブラリ本体のコード変更はなく `1.12.0` と機能的に同一。
- README の Stable マーカーと CHANGELOG を更新。

## 検証

- ローカルで publish の該当ステップ列を再現し通過を確認: `pnpm -C packages/nanoka build && pnpm -C packages/nanoka-auth build && pnpm -C examples/basic typecheck`
- `pnpm lint` 追加のエラーなし。

## マージ後

`main` マージで `auto-tag` が `v1.12.1` を打ち、修正後の `publish.yml` で npm 公開まで進む想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)