### PR TITLE
chore!: engines.node >=22（全パッケージ・v2.0.0）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/onboarding.yml
+++ b/.github/workflows/onboarding.yml
@@ -22,7 +22,7 @@ jobs:
           version: 9.15.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Run onboarding happy path E2E
@@ -37,7 +37,7 @@ jobs:
           version: 9.15.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Run onboarding zod@^4 regression E2E (expects typecheck failure)
@@ -53,7 +53,7 @@ jobs:
           version: 9.15.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: bash e2e/onboarding/scripts/run-onboarding-scaffold.sh

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Nanoka is organized as a `pnpm` workspace:
 
 ## Prerequisites
 
-- **Node.js >=20** — per `packages/nanoka/package.json` `engines.node` field
+- **Node.js >=22** — per `packages/nanoka/package.json` `engines.node` field
 - **pnpm 9.15.x** — pinned in `packageManager` field; we recommend `corepack enable` to use it automatically
 
 ## Development workflow

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1, with Turso/libSQL support through the adapter layer.
 
-**Stable 1.x.** Supports Zod 3 and Zod 4.
+**Stable 2.x.** Supports Zod 3 and Zod 4.
 
 ## What is this
 

--- a/packages/create-nanoka-app/package.json
+++ b/packages/create-nanoka-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nanoka-app",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "description": "Create a new Nanoka (Hono + D1) project",
   "type": "module",
   "bin": {
@@ -12,7 +12,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nanoka-auth/CHANGELOG.md
+++ b/packages/nanoka-auth/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@nanokajs/auth` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] — 2026-07-18
+
+### Changed
+
+- **BREAKING**: `engines.node` を `>= 20` から `>= 22` に引き上げ（core / create-nanoka-app と同時実施）。開発ツールチェーン（wrangler 4 / vite 8）が既に Node 22+ を要求しており、宣言を実態に合わせた。ランタイム（Cloudflare Workers）への影響はなし。
+
 ## [1.6.3] — 2026-07-15
 
 ### Changed

--- a/packages/nanoka-auth/README.md
+++ b/packages/nanoka-auth/README.md
@@ -10,7 +10,7 @@ Provides credential validation, JWT issuance, and Hono middleware — built on `
 pnpm add @nanokajs/auth
 ```
 
-Peer dependencies: `@nanokajs/core ^1.0.0`, `hono ^4.0.0`.
+Peer dependencies: `@nanokajs/core ^1.0.0 || ^2.0.0`, `hono ^4.0.0`.
 
 ## Usage
 

--- a/packages/nanoka-auth/package.json
+++ b/packages/nanoka-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/auth",
-  "version": "1.6.3",
+  "version": "2.0.0",
   "type": "module",
   "description": "Authentication utilities for Nanoka on Cloudflare Workers.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",
@@ -21,7 +21,7 @@
     "d1"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "exports": {

--- a/packages/nanoka-auth/package.json
+++ b/packages/nanoka-auth/package.json
@@ -49,7 +49,7 @@
     "prepublishOnly": "pnpm build && pnpm test && pnpm typecheck"
   },
   "peerDependencies": {
-    "@nanokajs/core": "^1.0.0",
+    "@nanokajs/core": "^1.0.0 || ^2.0.0",
     "hono": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/nanoka/CHANGELOG.md
+++ b/packages/nanoka/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@nanokajs/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] — 2026-07-18
+
+### Changed
+
+- **BREAKING**: `engines.node` を `>= 20` から `>= 22` に引き上げ（`@nanokajs/core` / `@nanokajs/auth` / `create-nanoka-app` の全パッケージ）。開発ツールチェーン（wrangler 4 / vite 8）が既に Node 22+ を要求しており、宣言を実態に合わせた。ランタイム（Cloudflare Workers）への影響はなし。Node 20 環境でのローカル開発は非サポートとなる。
+
 ## [1.13.1] — 2026-07-15
 
 ### Changed

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -17,7 +17,7 @@ Targets **Cloudflare Workers + D1 (SQLite)** as first-class. Hono-compatible rou
 
 ## Status
 
-**Stable (1.12.1).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()`, mutation/findOne SQL expression and `in` operator in `where` — is stable under SemVer.
+**Stable (2.0.0).** Core API-boundary surface — field policies, `inputSchema` / `outputSchema`, validator presets, `t.json(zodSchema)`, field accessor API, Zod 3 / 4 support, OpenAPI component seed, `t.timestamp().defaultNow()`, mutation/findOne SQL expression and `in` operator in `where` — is stable under SemVer.
 
 ## Stable API surface (1.0)
 

--- a/packages/nanoka/README.md
+++ b/packages/nanoka/README.md
@@ -45,7 +45,7 @@ pnpm add @nanokajs/core drizzle-orm zod
 pnpm add -D typescript drizzle-kit @cloudflare/workers-types
 ```
 
-> **Node.js 22 or later is required for the development toolchain.** `wrangler` 4 declares `engines.node >= 22` (and `vite` 8 requires `>= 22.12`), so local dev / test tooling needs Node 22+. The `@nanokajs/core` library itself still declares `engines.node >= 20` — it runs on Cloudflare Workers, and the runtime surface is unchanged.
+> **Node.js 22 or later is required for the development toolchain.** `wrangler` 4 declares `engines.node >= 22` (and `vite` 8 requires `>= 22.12`), so local dev / test tooling needs Node 22+. As of v2.0.0, `@nanokajs/core` also declares `engines.node >= 22`, matching the toolchain requirement (the library still runs on Cloudflare Workers; the runtime surface is unchanged).
 
 Then add a `types` entry to `tsconfig.json` so `D1Database`, `Request`, `ExecutionContext`, and `crypto` resolve as ambient globals (no per-file imports needed):
 

--- a/packages/nanoka/package.json
+++ b/packages/nanoka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanokajs/core",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "type": "module",
   "description": "Thin wrapper over Hono + Drizzle + Zod for Cloudflare Workers + D1. 80% automatic, 20% explicit.",
   "author": "Eiichiro Iriguchi <eiichiro_iriguchi@a-1ro.dev>",
@@ -23,7 +23,7 @@
     "validation"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## Summary

#150 で「別途検討」としていた major 判断の実施（えいいちろう承認済み・2026-07-18）。

- `@nanokajs/core` / `@nanokajs/auth` / `create-nanoka-app` の `engines.node` を `>=20` → `>=22` に統一
- 3パッケージとも **v2.0.0** に引き上げ
- CHANGELOG に BREAKING 明記・README の注記を更新

ランタイムは Cloudflare Workers のため実行面の影響はなし。開発ツールチェーン（wrangler 4 / vite 8）は既に Node 22+ 要求のため、宣言を実態に合わせる変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)